### PR TITLE
Extensions from nginx-retry development

### DIFF
--- a/nginx-sys/wrapper.h
+++ b/nginx-sys/wrapper.h
@@ -9,12 +9,3 @@ const size_t NGX_RS_HTTP_SRV_CONF_OFFSET = NGX_HTTP_SRV_CONF_OFFSET;
 const size_t NGX_RS_HTTP_LOC_CONF_OFFSET = NGX_HTTP_LOC_CONF_OFFSET;
 
 const char *NGX_RS_MODULE_SIGNATURE = NGX_MODULE_SIGNATURE;
-
-// Wrappers for inline functions here
-void ngx_add_ev_timer(ngx_event_t *ev, ngx_msec_t time) {
-  ngx_add_timer(ev, time);
-}
-
-void ngx_del_ev_timer(ngx_event_t *ev) {
-  ngx_event_del_timer(ev);
-}

--- a/nginx-sys/wrapper.h
+++ b/nginx-sys/wrapper.h
@@ -9,3 +9,12 @@ const size_t NGX_RS_HTTP_SRV_CONF_OFFSET = NGX_HTTP_SRV_CONF_OFFSET;
 const size_t NGX_RS_HTTP_LOC_CONF_OFFSET = NGX_HTTP_LOC_CONF_OFFSET;
 
 const char *NGX_RS_MODULE_SIGNATURE = NGX_MODULE_SIGNATURE;
+
+// Wrappers for inline functions here
+void ngx_add_ev_timer(ngx_event_t *ev, ngx_msec_t time) {
+  ngx_add_timer(ev, time);
+}
+
+void ngx_del_ev_timer(ngx_event_t *ev) {
+  ngx_event_del_timer(ev);
+}

--- a/src/core/event.rs
+++ b/src/core/event.rs
@@ -1,0 +1,52 @@
+use crate::ffi::*;
+
+#[repr(transparent)]
+pub struct Event(ngx_event_t);
+impl Event {
+    pub fn add_timer(&mut self, timer: ngx_msec_t) {
+        let key: ngx_msec_int_t = unsafe {ngx_current_msec as isize + timer as isize};
+        if self.0.timer_set() == 0 {
+            /* FROM NGX:
+             * Use a previous timer value if difference between it and a new
+             * value is less than NGX_TIMER_LAZY_DELAY milliseconds: this allows
+             * to minimize the rbtree operations for fast connections.
+             */
+            let diff = key - self.0.timer.key as ngx_msec_int_t;
+            if diff.abs() < NGX_TIMER_LAZY_DELAY as isize {
+                // TODO add debugging macro
+                return;
+            }
+
+            self.del_timer();
+        }
+
+        self.0.timer.key = key as ngx_msec_t;
+        // TODO add debugging macro
+        unsafe {
+            ngx_rbtree_insert(
+                &mut ngx_event_timer_rbtree as *mut _,
+                &mut self.0.timer as *mut _,
+            );
+        }
+
+        self.0.set_timer_set(1);
+    }
+
+    pub fn del_timer(&mut self) {
+        unsafe {
+            ngx_rbtree_delete(
+                &mut ngx_event_timer_rbtree as *mut _,
+                &mut self.0.timer as *mut _,
+            );
+        }
+
+        self.0.set_timer_set(0);
+    }
+}
+
+impl From<*mut ngx_event_t> for &mut Event {
+    fn from(evt: *mut ngx_event_t) -> Self {
+        unsafe {&mut *evt.cast::<Event>()}
+    }
+}
+

--- a/src/core/event.rs
+++ b/src/core/event.rs
@@ -1,7 +1,8 @@
 use crate::ffi::*;
 
 #[repr(transparent)]
-pub struct Event(ngx_event_t);
+pub struct Event(pub ngx_event_t);
+
 impl Event {
     pub fn add_timer(&mut self, timer: ngx_msec_t) {
         let key: ngx_msec_int_t = unsafe {ngx_current_msec as isize + timer as isize};
@@ -41,6 +42,10 @@ impl Event {
         }
 
         self.0.set_timer_set(0);
+    }
+
+    pub unsafe fn new_for_request<'a>(req: &'a mut crate::http::Request) -> &'a mut Event {
+        &mut *(req.pool().alloc(std::mem::size_of::<ngx_event_t>()) as *mut Event)
     }
 }
 

--- a/src/core/event.rs
+++ b/src/core/event.rs
@@ -6,7 +6,7 @@ pub struct Event(pub ngx_event_t);
 impl Event {
     pub fn add_timer(&mut self, timer: ngx_msec_t) {
         let key: ngx_msec_int_t = unsafe {ngx_current_msec as isize + timer as isize};
-        if self.0.timer_set() == 0 {
+        if self.0.timer_set() != 0 {
             /* FROM NGX:
              * Use a previous timer value if difference between it and a new
              * value is less than NGX_TIMER_LAZY_DELAY milliseconds: this allows
@@ -44,7 +44,7 @@ impl Event {
         self.0.set_timer_set(0);
     }
 
-    pub unsafe fn new_for_request<'a>(req: &'a mut crate::http::Request) -> &'a mut Event {
+    pub unsafe fn new_for_request(req: &crate::http::Request) -> &mut Event {
         &mut *(req.pool().alloc(std::mem::size_of::<ngx_event_t>()) as *mut Event)
     }
 }
@@ -55,3 +55,8 @@ impl From<*mut ngx_event_t> for &mut Event {
     }
 }
 
+impl Into<*mut ngx_event_t> for &mut Event {
+    fn into(self) -> *mut ngx_event_t {
+        &mut self.0 as *mut ngx_event_t
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,6 +2,7 @@ mod buffer;
 mod pool;
 mod status;
 mod string;
+mod event;
 
 pub use buffer::*;
 pub use pool::*;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -8,6 +8,7 @@ pub use buffer::*;
 pub use pool::*;
 pub use status::*;
 pub use string::*;
+pub use event::*;
 
 /// Static empty configuration directive initializer for [`ngx_command_t`].
 ///

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -269,10 +269,15 @@ impl Request {
         Status::NGX_DONE
     }
 
-    /// how many subrequests deep is this request?
+    /// how many subrequests are available to make in this request
     /// will return NGX_HTTP_MAX_SUBREQUESTS for a parent request.
     pub fn subrequests_available(&self) -> u32 {
-        self.0.subrequests()
+        // 1 is subtracted because this function was caught returning 1 extra
+        // The return value should be (50, 0), with the parent request returning
+        // NGX_HTTP_MAX_SUBREQUESTS.
+        // See http://nginx.org/en/docs/dev/development_guide.html#http_subrequests
+        // for more information
+        self.0.subrequests() - 1
     }
 
     /// Send a subrequest

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -269,6 +269,7 @@ impl Request {
     pub fn subrequest(
         &self,
         uri: &str,
+        flags: u32,
         module: &ngx_module_t,
         post_callback: unsafe extern "C" fn(*mut ngx_http_request_t, *mut c_void, ngx_int_t) -> ngx_int_t,
     ) -> Status {
@@ -293,7 +294,7 @@ impl Request {
                 std::ptr::null_mut(),
                 &mut psr as *mut _,
                 sub_ptr as *mut _,
-                NGX_HTTP_SUBREQUEST_WAITED as _,
+                flags as _,
             )
         };
 

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -187,6 +187,15 @@ impl Request {
         self.0.headers_out.status = status.into();
     }
 
+    /// Set HTTP Status Line of response
+    pub fn set_status_line(&mut self, status_line: ngx_str_t) {
+        self.0.headers_out.status_line = status_line;
+    }
+
+    pub fn get_status_line(&mut self) -> &NgxStr {
+        unsafe {NgxStr::from_ngx_str(self.0.headers_out.status_line)}
+    }
+
     pub fn get_status(&self) -> HTTPStatus {
         HTTPStatus(self.0.headers_out.status)
     }

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -270,9 +270,9 @@ impl Request {
     }
 
     /// how many subrequests deep is this request?
-    /// will return 0 for a parent request.
-    pub fn subrequest_depth(&self) -> u32 {
-        NGX_HTTP_MAX_SUBREQUESTS - self.0.subrequests()
+    /// will return NGX_HTTP_MAX_SUBREQUESTS for a parent request.
+    pub fn subrequests_available(&self) -> u32 {
+        self.0.subrequests()
     }
 
     /// Send a subrequest

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -313,13 +313,6 @@ impl Request {
             )
         };
 
-        // ngx_http_subrequest() ensures that the pointer is no longer null
-        let sr = unsafe { &mut *psr };
-
-        if sr.request_body.is_null() {
-            return Status::NGX_ERROR;
-        }
-        sr.set_header_only(1 as _);
         Status(r)
     }
 

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -187,6 +187,10 @@ impl Request {
         self.0.headers_out.status = status.into();
     }
 
+    pub fn get_status(&self) -> HTTPStatus {
+        HTTPStatus(self.0.headers_out.status)
+    }
+
     pub fn add_header_in(&mut self, key: &str, value: &str) -> Option<()> {
         let table: *mut ngx_table_elt_t = unsafe { ngx_list_push(&mut self.0.headers_in.headers) as _ };
         add_to_ngx_table(table, self.0.pool, key, value)

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -265,6 +265,12 @@ impl Request {
         Status::NGX_DONE
     }
 
+    /// how many subrequests deep is this request?
+    /// will return 0 for a parent request.
+    pub fn subrequest_depth(&self) -> u32 {
+        NGX_HTTP_MAX_SUBREQUESTS - self.0.subrequests()
+    }
+
     /// Send a subrequest
     pub fn subrequest(
         &self,

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -313,14 +313,8 @@ impl Request {
             )
         };
 
-        // previously call of ngx_http_subrequest() would ensure that the pointer is not null anymore
-        let mut sr = unsafe { &mut *psr };
-
-        /*
-         * allocate fake request body to avoid attempts to read it and to make
-         * sure real body file (if already read) won't be closed by upstream
-         */
-        sr.request_body = self.pool().alloc(std::mem::size_of::<ngx_http_request_body_t>()) as *mut _;
+        // ngx_http_subrequest() ensures that the pointer is no longer null
+        let sr = unsafe { &mut *psr };
 
         if sr.request_body.is_null() {
             return Status::NGX_ERROR;

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -186,8 +186,10 @@ impl Request {
         HTTPStatus(self.0.headers_out.status)
     }
 
-    pub fn get_headers_out(&self) -> *mut ngx_http_headers_out_t {
-        &self.0.headers_out as *const _ as *mut _
+    pub fn increment_cycle_count(&mut self) {
+        self.0.set_count(
+            self.0.count() + 1
+        );
     }
 
     pub fn add_header_in(&mut self, key: &str, value: &str) -> Option<()> {

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -182,22 +182,12 @@ impl Request {
         unsafe { NgxStr::from_ngx_str((*self.0.headers_in.user_agent).value) }
     }
 
-    /// Set HTTP status of response.
-    pub fn set_status(&mut self, status: HTTPStatus) {
-        self.0.headers_out.status = status.into();
-    }
-
-    /// Set HTTP Status Line of response
-    pub fn set_status_line(&mut self, status_line: ngx_str_t) {
-        self.0.headers_out.status_line = status_line;
-    }
-
-    pub fn get_status_line(&mut self) -> ngx_str_t {
-        self.0.headers_out.status_line.clone()
-    }
-
     pub fn get_status(&self) -> HTTPStatus {
         HTTPStatus(self.0.headers_out.status)
+    }
+
+    pub fn get_headers_out(&self) -> *mut ngx_http_headers_out_t {
+        &self.0.headers_out as *const _ as *mut _
     }
 
     pub fn add_header_in(&mut self, key: &str, value: &str) -> Option<()> {


### PR DESCRIPTION
### Proposed changes
- minimal bindings for events (`nginx_event_t` and company) [(see example use here)](https://github.com/nginxinc/nginx-retry/blob/35690eb85e56440427874b604fab6c6800ca4026/src/retry.rs#L141)
- getters for request status and subrequest depth
- cycle count increment
- flags as argument to subrequest
- subrequest can accept a custom data [(see example use here)](https://github.com/nginxinc/nginx-retry/blob/35690eb85e56440427874b604fab6c6800ca4026/src/retry.rs#L178)
- do not automatically nuke the subrequest body. that should be up to the caller.

### Testing
- All changes tested with [nginx-retry](github.com/nginxinc/nginx-retry).
- Other modules have not yet been tested for compatibility with these changes.