### PR TITLE
cargo: make macOS linker flags workaround apply to Apple silicon

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,11 @@
 #
 # https://stackoverflow.com/questions/28124221/error-linking-with-cc-failed-exit-code-1
 #
+[target.aarch64-apple-darwin]
+rustflags = [
+  "-C", "link-arg=-undefined",
+  "-C", "link-arg=dynamic_lookup",
+]
 [target.x86_64-apple-darwin]
 rustflags = [
   "-C", "link-arg=-undefined",


### PR DESCRIPTION
This workaround is required for both Intel and Apple silicon Macs. 

I do not think there is a way to target both triples without duplication.