### PR TITLE
Add Event timers and supporting utilities (+ lint and fmt)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "ngx"
-version = "0.3.0-beta"
+version = "0.4.0-beta"
 dependencies = [
  "nginx-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "ngx"
-version = "0.3.0-beta"
+version = "0.4.0-beta"
 edition = "2021"
 autoexamples = false
 categories = ["api-bindings", "network-programming"]

--- a/nginx-sys/wrapper.h
+++ b/nginx-sys/wrapper.h
@@ -9,12 +9,3 @@ const size_t NGX_RS_HTTP_SRV_CONF_OFFSET = NGX_HTTP_SRV_CONF_OFFSET;
 const size_t NGX_RS_HTTP_LOC_CONF_OFFSET = NGX_HTTP_LOC_CONF_OFFSET;
 
 const char *NGX_RS_MODULE_SIGNATURE = NGX_MODULE_SIGNATURE;
-
-// Wrappers for inline functions here
-void ngx_add_ev_timer(ngx_event_t *ev, ngx_msec_t time) {
-  ngx_add_timer(ev, time);
-}
-
-void ngx_del_ev_timer(ngx_event_t *ev) {
-  ngx_event_del_timer(ev);
-}

--- a/nginx-sys/wrapper.h
+++ b/nginx-sys/wrapper.h
@@ -9,3 +9,12 @@ const size_t NGX_RS_HTTP_SRV_CONF_OFFSET = NGX_HTTP_SRV_CONF_OFFSET;
 const size_t NGX_RS_HTTP_LOC_CONF_OFFSET = NGX_HTTP_LOC_CONF_OFFSET;
 
 const char *NGX_RS_MODULE_SIGNATURE = NGX_MODULE_SIGNATURE;
+
+// Wrappers for inline functions here
+void ngx_add_ev_timer(ngx_event_t *ev, ngx_msec_t time) {
+  ngx_add_timer(ev, time);
+}
+
+void ngx_del_ev_timer(ngx_event_t *ev) {
+  ngx_event_del_timer(ev);
+}

--- a/src/core/event.rs
+++ b/src/core/event.rs
@@ -1,11 +1,20 @@
 use crate::ffi::*;
+use crate::ngx_log_debug_mask;
 
+/// Wrapper struct for an `ngx_event_t` pointer, provides an interface into timer methods.
 #[repr(transparent)]
 pub struct Event(pub ngx_event_t);
 
 impl Event {
-    pub fn add_timer(&mut self, timer: ngx_msec_t) {
-        let key: ngx_msec_int_t = unsafe {ngx_current_msec as isize + timer as isize};
+    #[inline]
+    fn ident(&self) -> i32 {
+        let conn = self.0.data as *const ngx_connection_t;
+        unsafe { (*conn).fd }
+    }
+
+    /// Adds a timer to this event. Argument `timer` is in milliseconds.
+    pub fn add_timer(&mut self, timer_msec: ngx_msec_t) {
+        let key: ngx_msec_int_t = unsafe { ngx_current_msec as isize + timer_msec as isize };
         if self.0.timer_set() != 0 {
             /* FROM NGX:
              * Use a previous timer value if difference between it and a new
@@ -14,7 +23,14 @@ impl Event {
              */
             let diff = key - self.0.timer.key as ngx_msec_int_t;
             if diff.abs() < NGX_TIMER_LAZY_DELAY as isize {
-                // TODO add debugging macro
+                ngx_log_debug_mask!(
+                    NGX_LOG_DEBUG_EVENT,
+                    self.0.log,
+                    "event time: {}, old: {:?}, new: {:?}",
+                    self.ident(),
+                    self.0.timer.key,
+                    key
+                );
                 return;
             }
 
@@ -22,55 +38,79 @@ impl Event {
         }
 
         self.0.timer.key = key as ngx_msec_t;
-        // TODO add debugging macro
+        ngx_log_debug_mask!(
+            NGX_LOG_DEBUG_EVENT,
+            self.0.log,
+            "event time: {}, old: {:?}, new: {:?}",
+            self.ident(),
+            self.0.timer.key,
+            key
+        );
         unsafe {
-            ngx_rbtree_insert(
-                &mut ngx_event_timer_rbtree as *mut _,
-                &mut self.0.timer as *mut _,
-            );
+            ngx_rbtree_insert(&mut ngx_event_timer_rbtree as *mut _, &mut self.0.timer as *mut _);
         }
 
         self.0.set_timer_set(1);
     }
 
+    /// Deletes an associated timer from this event.
     pub fn del_timer(&mut self) {
+        ngx_log_debug_mask!(
+            NGX_LOG_DEBUG_EVENT,
+            self.0.log,
+            "event timer del: {}:{:?}",
+            self.ident(),
+            self.0.timer.key
+        );
         unsafe {
-            ngx_rbtree_delete(
-                &mut ngx_event_timer_rbtree as *mut _,
-                &mut self.0.timer as *mut _,
-            );
+            ngx_rbtree_delete(&mut ngx_event_timer_rbtree as *mut _, &mut self.0.timer as *mut _);
         }
 
         self.0.set_timer_set(0);
     }
 
-    /// translated from ngx_post_event macro
-    pub fn post_to_queue(&mut self, queue: *mut ngx_queue_t) {
-        if self.0.posted() == 0{
+    /// Add event to processing queue. Translated from ngx_post_event macro.
+    ///
+    /// # Safety
+    /// This function is marked unsafe because it dereferences a raw pointer. The pointer (queue)
+    /// MUST NOT be null to satisfy its contract, will panic with null input.
+    ///
+    /// # Panics
+    /// Panics if the given queue is null.
+    pub unsafe fn post_to_queue(&mut self, queue: *mut ngx_queue_t) {
+        assert!(!queue.is_null(), "queue is empty");
+        if self.0.posted() == 0 {
             self.0.set_posted(1);
-            unsafe {
-                // translated from ngx_queue_insert_tail macro
-                self.0.queue.prev = (*queue).prev;
-                (*self.0.queue.prev).next = &self.0.queue as *const _ as *mut _;
-                self.0.queue.next = queue;
-                (*queue).prev = &self.0.queue as *const _ as *mut _;
-            }
+            // translated from ngx_queue_insert_tail macro
+            self.0.queue.prev = (*queue).prev;
+            (*self.0.queue.prev).next = &self.0.queue as *const _ as *mut _;
+            self.0.queue.next = queue;
+            (*queue).prev = &self.0.queue as *const _ as *mut _;
         }
     }
 
-    pub unsafe fn new_for_request(req: &crate::http::Request) -> &mut Event {
-        &mut *(req.pool().alloc(std::mem::size_of::<ngx_event_t>()) as *mut Event)
+    /// new_for_request creates an new Event (ngx_event_t) from the Request pool.
+    ///
+    /// # Safety
+    /// This function is marked as unsafe because it involves dereferencing a raw pointer memory
+    /// allocation from the underlying Nginx pool allocator.
+    ///
+    /// # Returns
+    /// An `Option<&mut Event>` representing the result of the allocation. `Some(&mut Event)`
+    /// indicates successful allocation, while `None` indicates a null Event.
+    pub unsafe fn new_for_request(req: &mut crate::http::Request) -> Option<&mut Event> {
+        Some(&mut *(req.pool().alloc(std::mem::size_of::<ngx_event_t>()) as *mut Event))
     }
 }
 
 impl From<*mut ngx_event_t> for &mut Event {
     fn from(evt: *mut ngx_event_t) -> Self {
-        unsafe {&mut *evt.cast::<Event>()}
+        unsafe { &mut *evt.cast::<Event>() }
     }
 }
 
-impl Into<*mut ngx_event_t> for &mut Event {
-    fn into(self) -> *mut ngx_event_t {
-        &mut self.0 as *mut ngx_event_t
+impl From<&mut Event> for *mut ngx_event_t {
+    fn from(val: &mut Event) -> Self {
+        &mut val.0 as *mut ngx_event_t
     }
 }

--- a/src/core/event.rs
+++ b/src/core/event.rs
@@ -1,0 +1,52 @@
+use crate::ffi::*;
+
+#[repr(transparent)]
+pub struct Event(ngx_event_t);
+impl Event {
+    pub fn add_timer(&mut self, timer: ngx_msec_t) {
+        let key: ngx_msec_int_t = unsafe {ngx_current_msec as isize + timer as isize};
+        if self.0.timer_set() == 0 {
+            /* FROM NGX:
+             * Use a previous timer value if difference between it and a new
+             * value is less than NGX_TIMER_LAZY_DELAY milliseconds: this allows
+             * to minimize the rbtree operations for fast connections.
+             */
+            let diff = key - self.0.timer.key as ngx_msec_int_t;
+            if diff.abs() < NGX_TIMER_LAZY_DELAY as isize {
+                // TODO add debugging macro
+                return;
+            }
+
+            self.del_timer();
+        }
+
+        self.0.timer.key = key as ngx_msec_t;
+        // TODO add debugging macro
+        unsafe {
+            ngx_rbtree_insert(
+                &mut ngx_event_timer_rbtree as *mut _,
+                &mut self.0.timer as *mut _,
+            );
+        }
+
+        self.0.set_timer_set(1);
+    }
+
+    pub fn del_timer(&mut self) {
+        unsafe {
+            ngx_rbtree_delete(
+                &mut ngx_event_timer_rbtree as *mut _,
+                &mut self.0.timer as *mut _,
+            );
+        }
+
+        self.0.set_timer_set(0);
+    }
+}
+
+impl From<*mut ngx_event_t> for &mut Event {
+    fn from(evt: *mut ngx_event_t) -> Self {
+        unsafe {&mut *evt.cast::<Event>()}
+    }
+}
+

--- a/src/core/event.rs
+++ b/src/core/event.rs
@@ -1,7 +1,8 @@
 use crate::ffi::*;
 
 #[repr(transparent)]
-pub struct Event(ngx_event_t);
+pub struct Event(pub ngx_event_t);
+
 impl Event {
     pub fn add_timer(&mut self, timer: ngx_msec_t) {
         let key: ngx_msec_int_t = unsafe {ngx_current_msec as isize + timer as isize};
@@ -41,6 +42,10 @@ impl Event {
         }
 
         self.0.set_timer_set(0);
+    }
+
+    pub unsafe fn new_for_request<'a>(req: &'a mut crate::http::Request) -> &'a mut Event {
+        &mut *(req.pool().alloc(std::mem::size_of::<ngx_event_t>()) as *mut Event)
     }
 }
 

--- a/src/core/event.rs
+++ b/src/core/event.rs
@@ -6,7 +6,7 @@ pub struct Event(pub ngx_event_t);
 impl Event {
     pub fn add_timer(&mut self, timer: ngx_msec_t) {
         let key: ngx_msec_int_t = unsafe {ngx_current_msec as isize + timer as isize};
-        if self.0.timer_set() == 0 {
+        if self.0.timer_set() != 0 {
             /* FROM NGX:
              * Use a previous timer value if difference between it and a new
              * value is less than NGX_TIMER_LAZY_DELAY milliseconds: this allows
@@ -44,7 +44,7 @@ impl Event {
         self.0.set_timer_set(0);
     }
 
-    pub unsafe fn new_for_request<'a>(req: &'a mut crate::http::Request) -> &'a mut Event {
+    pub unsafe fn new_for_request(req: &crate::http::Request) -> &mut Event {
         &mut *(req.pool().alloc(std::mem::size_of::<ngx_event_t>()) as *mut Event)
     }
 }
@@ -55,3 +55,8 @@ impl From<*mut ngx_event_t> for &mut Event {
     }
 }
 
+impl Into<*mut ngx_event_t> for &mut Event {
+    fn into(self) -> *mut ngx_event_t {
+        &mut self.0 as *mut ngx_event_t
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,6 +2,7 @@ mod buffer;
 mod pool;
 mod status;
 mod string;
+mod event;
 
 pub use buffer::*;
 pub use pool::*;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,14 +1,14 @@
 mod buffer;
+mod event;
 mod pool;
 mod status;
 mod string;
-mod event;
 
 pub use buffer::*;
+pub use event::*;
 pub use pool::*;
 pub use status::*;
 pub use string::*;
-pub use event::*;
 
 /// Static empty configuration directive initializer for [`ngx_command_t`].
 ///

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -8,6 +8,7 @@ pub use buffer::*;
 pub use pool::*;
 pub use status::*;
 pub use string::*;
+pub use event::*;
 
 /// Static empty configuration directive initializer for [`ngx_command_t`].
 ///

--- a/src/http/flags.rs
+++ b/src/http/flags.rs
@@ -1,0 +1,187 @@
+use crate::ffi::ngx_uint_t;
+use std::{
+    mem,
+    ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Not},
+};
+
+/// SubrequestFlags is a bitmask for NGINX subrequest control.
+/// Refer to https://nginx.org/en/docs/dev/development_guide.html#http_subrequests for more
+/// details.
+///
+/// The following flags are available:
+/// None: Zero value of the subrequest flag.
+/// InMemory - Output is not sent to the client, but rather stored in memory. The flag only affects subrequests which are processed by one of the proxying modules. After a subrequest is finalized its output is available in r->out of type ngx_buf_t.
+/// Waited - The subrequest's done flag is set even if the subrequest is not active when it is finalized. This subrequest flag is used by the SSI filter.
+/// Clone - The subrequest is created as a clone of its parent. It is started at the same location and proceeds from the same phase as the parent request.
+/// Background - The subrequest operates in the background (useful for background cache updates), this type of subrequest does not block any other subrequests or the main request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(u32)]
+pub enum SubrequestFlags {
+    /// None: Zero value of the subrequest flag.
+    None = 0,
+    // unused = 1 ngx_http_request.h:65
+    /// InMemory - Output is not sent to the client, but rather stored in memory. The flag only affects subrequests which are processed by one of the proxying modules. After a subrequest is finalized its output is available in r->out of type ngx_buf_t.
+    InMemory = 2,
+    /// Waited - The subrequest's done flag is set even if the subrequest is not active when it is finalized. This subrequest flag is used by the SSI filter.
+    Waited = 4,
+    /// Clone - The subrequest is created as a clone of its parent. It is started at the same location and proceeds from the same phase as the parent request.
+    Clone = 8,
+    /// Background - The subrequest operates in the background (useful for background cache updates), this type of subrequest does not block any other subrequests or the main request.
+    Background = 16,
+}
+
+impl BitAnd for SubrequestFlags {
+    type Output = Self;
+
+    #[inline]
+    fn bitand(self, rhs: Self) -> Self {
+        unsafe { mem::transmute(self as u32 & rhs as u32) }
+    }
+}
+
+impl BitAndAssign for SubrequestFlags {
+    #[inline]
+    fn bitand_assign(&mut self, rhs: Self) {
+        *self = *self & rhs;
+    }
+}
+
+impl BitOr for SubrequestFlags {
+    type Output = Self;
+
+    #[inline]
+    fn bitor(self, rhs: Self) -> Self {
+        unsafe { mem::transmute(self as u32 | rhs as u32) }
+    }
+}
+
+impl BitOrAssign for SubrequestFlags {
+    #[inline]
+    fn bitor_assign(&mut self, rhs: Self) {
+        *self = *self | rhs;
+    }
+}
+
+impl BitXor for SubrequestFlags {
+    type Output = Self;
+
+    #[inline]
+    fn bitxor(self, rhs: Self) -> Self {
+        unsafe { std::mem::transmute(self as u32 ^ rhs as u32) }
+    }
+}
+
+impl BitXorAssign for SubrequestFlags {
+    #[inline]
+    fn bitxor_assign(&mut self, rhs: Self) {
+        *self = *self ^ rhs;
+    }
+}
+
+impl Not for SubrequestFlags {
+    type Output = Self;
+
+    #[inline]
+    fn not(self) -> Self {
+        unsafe { std::mem::transmute(!(self as u32)) }
+    }
+}
+
+impl From<SubrequestFlags> for u32 {
+    #[inline]
+    fn from(flags: SubrequestFlags) -> Self {
+        flags as u32
+    }
+}
+
+impl From<SubrequestFlags> for ngx_uint_t {
+    #[inline]
+    fn from(flags: SubrequestFlags) -> Self {
+        flags as ngx_uint_t
+    }
+}
+
+impl SubrequestFlags {
+    /// Tests if flag(s) are set on the SubrequestFlags.
+    #[inline]
+    pub fn has_flag(&self, flag: SubrequestFlags) -> bool {
+        (*self as u32 & flag as u32) != 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_and() {
+        let mut flag: SubrequestFlags = SubrequestFlags::Background;
+        assert_eq!(flag.has_flag(SubrequestFlags::Background), true);
+
+        let test_flag = flag & SubrequestFlags::InMemory;
+        assert_eq!(test_flag, SubrequestFlags::None);
+        assert_eq!(test_flag.has_flag(SubrequestFlags::Background), false);
+        assert_eq!(test_flag.has_flag(SubrequestFlags::InMemory), false);
+
+        flag &= SubrequestFlags::Clone;
+        assert_eq!(flag, SubrequestFlags::None);
+        assert_eq!(flag.has_flag(SubrequestFlags::Clone), false);
+        assert_eq!(flag.has_flag(SubrequestFlags::Background), false);
+    }
+
+    #[test]
+    fn test_or() {
+        let mut flag: SubrequestFlags = SubrequestFlags::Background;
+        assert_eq!(flag.has_flag(SubrequestFlags::Background), true);
+
+        let test_flag = flag | SubrequestFlags::InMemory;
+        assert_eq!(test_flag as u32, 18);
+        assert_eq!(test_flag.has_flag(SubrequestFlags::Background), true);
+        assert_eq!(test_flag.has_flag(SubrequestFlags::InMemory), true);
+        assert_eq!(test_flag.has_flag(SubrequestFlags::Clone), false);
+
+        flag |= SubrequestFlags::Clone;
+        assert_eq!(flag as u32, 24);
+        assert_eq!(flag.has_flag(SubrequestFlags::Background), true);
+        assert_eq!(flag.has_flag(SubrequestFlags::Clone), true);
+        assert_eq!(flag.has_flag(SubrequestFlags::InMemory), false);
+    }
+
+    #[test]
+    fn test_xor() {
+        let mut flag: SubrequestFlags = SubrequestFlags::Background | SubrequestFlags::InMemory;
+        assert_eq!(flag as u32, 18);
+
+        let test_flag = flag ^ SubrequestFlags::Background;
+        assert_eq!(test_flag, SubrequestFlags::InMemory);
+        assert_eq!(test_flag.has_flag(SubrequestFlags::Background), false);
+        assert_eq!(test_flag.has_flag(SubrequestFlags::Clone), false);
+        assert_eq!(test_flag.has_flag(SubrequestFlags::InMemory), true);
+
+        flag ^= SubrequestFlags::Background;
+        assert_eq!(flag, SubrequestFlags::InMemory);
+        assert_eq!(flag.has_flag(SubrequestFlags::Background), false);
+        assert_eq!(flag.has_flag(SubrequestFlags::Clone), false);
+        assert_eq!(flag.has_flag(SubrequestFlags::InMemory), true);
+
+        flag ^= SubrequestFlags::Clone;
+        assert_eq!(flag as u32, 10);
+        assert_eq!(flag.has_flag(SubrequestFlags::Background), false);
+        assert_eq!(flag.has_flag(SubrequestFlags::Clone), true);
+        assert_eq!(flag.has_flag(SubrequestFlags::InMemory), true);
+    }
+
+    #[test]
+    fn test_not() {
+        let flag: SubrequestFlags = SubrequestFlags::Background | SubrequestFlags::InMemory;
+        assert_eq!(flag as u32, 18);
+
+        let test_flag: SubrequestFlags = flag & !SubrequestFlags::Background;
+        assert_eq!(test_flag, SubrequestFlags::InMemory);
+
+        assert_eq!(!SubrequestFlags::InMemory as i32, -3);
+        assert_eq!(!SubrequestFlags::Waited as i32, -5);
+        assert_eq!(!SubrequestFlags::Clone as i32, -9);
+        assert_eq!(!SubrequestFlags::Background as i32, -17);
+    }
+}

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,9 +1,11 @@
 mod conf;
+mod flags;
 mod module;
 mod request;
 mod status;
 
 pub use conf::*;
+pub use flags::*;
 pub use module::*;
 pub use request::*;
 pub use status::*;

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -191,6 +191,10 @@ impl Request {
         self.0.headers_out.status = status.into();
     }
 
+    pub fn get_status(&self) -> HTTPStatus {
+        HTTPStatus(self.0.headers_out.status)
+    }
+
     pub fn add_header_in(&mut self, key: &str, value: &str) -> Option<()> {
         let table: *mut ngx_table_elt_t = unsafe { ngx_list_push(&mut self.0.headers_in.headers) as _ };
         add_to_ngx_table(table, self.0.pool, key, value)

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -273,6 +273,7 @@ impl Request {
     pub fn subrequest(
         &self,
         uri: &str,
+        flags: u32,
         module: &ngx_module_t,
         post_callback: unsafe extern "C" fn(*mut ngx_http_request_t, *mut c_void, ngx_int_t) -> ngx_int_t,
     ) -> Status {
@@ -297,7 +298,7 @@ impl Request {
                 std::ptr::null_mut(),
                 &mut psr as *mut _,
                 sub_ptr as *mut _,
-                NGX_HTTP_SUBREQUEST_WAITED as _,
+                flags as _,
             )
         };
 

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -274,9 +274,9 @@ impl Request {
     }
 
     /// how many subrequests deep is this request?
-    /// will return 0 for a parent request.
-    pub fn subrequest_depth(&self) -> u32 {
-        NGX_HTTP_MAX_SUBREQUESTS - self.0.subrequests()
+    /// will return NGX_HTTP_MAX_SUBREQUESTS for a parent request.
+    pub fn subrequests_available(&self) -> u32 {
+        self.0.subrequests()
     }
 
     /// Send a subrequest

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -191,6 +191,15 @@ impl Request {
         self.0.headers_out.status = status.into();
     }
 
+    /// Set HTTP Status Line of response
+    pub fn set_status_line(&mut self, status_line: ngx_str_t) {
+        self.0.headers_out.status_line = status_line;
+    }
+
+    pub fn get_status_line(&mut self) -> &NgxStr {
+        unsafe {NgxStr::from_ngx_str(self.0.headers_out.status_line)}
+    }
+
     pub fn get_status(&self) -> HTTPStatus {
         HTTPStatus(self.0.headers_out.status)
     }

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -317,14 +317,8 @@ impl Request {
             )
         };
 
-        // previously call of ngx_http_subrequest() would ensure that the pointer is not null anymore
-        let mut sr = unsafe { &mut *psr };
-
-        /*
-         * allocate fake request body to avoid attempts to read it and to make
-         * sure real body file (if already read) won't be closed by upstream
-         */
-        sr.request_body = self.pool().alloc(std::mem::size_of::<ngx_http_request_body_t>()) as *mut _;
+        // ngx_http_subrequest() ensures that the pointer is no longer null
+        let sr = unsafe { &mut *psr };
 
         if sr.request_body.is_null() {
             return Status::NGX_ERROR;

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -196,8 +196,8 @@ impl Request {
         self.0.headers_out.status_line = status_line;
     }
 
-    pub fn get_status_line(&mut self) -> &NgxStr {
-        unsafe {NgxStr::from_ngx_str(self.0.headers_out.status_line)}
+    pub fn get_status_line(&mut self) -> ngx_str_t {
+        self.0.headers_out.status_line.clone()
     }
 
     pub fn get_status(&self) -> HTTPStatus {
@@ -299,6 +299,7 @@ impl Request {
         uri: &str,
         flags: u32,
         module: &ngx_module_t,
+        data: Option<*mut c_void>,
         post_callback: unsafe extern "C" fn(*mut ngx_http_request_t, *mut c_void, ngx_int_t) -> ngx_int_t,
     ) -> Status {
         let uri_ptr = &mut ngx_str_t::from_str(self.0.pool, uri) as *mut _;
@@ -310,7 +311,12 @@ impl Request {
         let post_subreq = sub_ptr as *const ngx_http_post_subrequest_t as *mut ngx_http_post_subrequest_t;
         unsafe {
             (*post_subreq).handler = Some(post_callback);
-            (*post_subreq).data = self.get_module_ctx_ptr(module); // WARN: safety! ensure that ctx is already set
+            if let Some(datum) = data {
+                (*post_subreq).data = datum;
+            } else {
+                // WARN: safety! ensure that ctx is already set
+                (*post_subreq).data = self.get_module_ctx_ptr(module);
+            }
         }
         // -------------
 

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -190,8 +190,10 @@ impl Request {
         HTTPStatus(self.0.headers_out.status)
     }
 
-    pub fn get_headers_out(&self) -> *mut ngx_http_headers_out_t {
-        &self.0.headers_out as *const _ as *mut _
+    pub fn increment_cycle_count(&mut self) {
+        self.0.set_count(
+            self.0.count() + 1
+        );
     }
 
     pub fn add_header_in(&mut self, key: &str, value: &str) -> Option<()> {

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -186,22 +186,12 @@ impl Request {
         unsafe { NgxStr::from_ngx_str((*self.0.headers_in.user_agent).value) }
     }
 
-    /// Set HTTP status of response.
-    pub fn set_status(&mut self, status: HTTPStatus) {
-        self.0.headers_out.status = status.into();
-    }
-
-    /// Set HTTP Status Line of response
-    pub fn set_status_line(&mut self, status_line: ngx_str_t) {
-        self.0.headers_out.status_line = status_line;
-    }
-
-    pub fn get_status_line(&mut self) -> ngx_str_t {
-        self.0.headers_out.status_line.clone()
-    }
-
     pub fn get_status(&self) -> HTTPStatus {
         HTTPStatus(self.0.headers_out.status)
+    }
+
+    pub fn get_headers_out(&self) -> *mut ngx_http_headers_out_t {
+        &self.0.headers_out as *const _ as *mut _
     }
 
     pub fn add_header_in(&mut self, key: &str, value: &str) -> Option<()> {

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -269,6 +269,12 @@ impl Request {
         Status::NGX_DONE
     }
 
+    /// how many subrequests deep is this request?
+    /// will return 0 for a parent request.
+    pub fn subrequest_depth(&self) -> u32 {
+        NGX_HTTP_MAX_SUBREQUESTS - self.0.subrequests()
+    }
+
     /// Send a subrequest
     pub fn subrequest(
         &self,

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -317,13 +317,6 @@ impl Request {
             )
         };
 
-        // ngx_http_subrequest() ensures that the pointer is no longer null
-        let sr = unsafe { &mut *psr };
-
-        if sr.request_body.is_null() {
-            return Status::NGX_ERROR;
-        }
-        sr.set_header_only(1 as _);
         Status(r)
     }
 

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -273,10 +273,15 @@ impl Request {
         Status::NGX_DONE
     }
 
-    /// how many subrequests deep is this request?
+    /// how many subrequests are available to make in this request
     /// will return NGX_HTTP_MAX_SUBREQUESTS for a parent request.
     pub fn subrequests_available(&self) -> u32 {
-        self.0.subrequests()
+        // 1 is subtracted because this function was caught returning 1 extra
+        // The return value should be (50, 0), with the parent request returning
+        // NGX_HTTP_MAX_SUBREQUESTS.
+        // See http://nginx.org/en/docs/dev/development_guide.html#http_subrequests
+        // for more information
+        self.0.subrequests() - 1
     }
 
     /// Send a subrequest

--- a/src/log.rs
+++ b/src/log.rs
@@ -27,3 +27,18 @@ macro_rules! ngx_log_debug_http {
         $crate::ngx_log_debug!(log, $($arg)*);
     }
 }
+
+#[macro_export]
+macro_rules! ngx_log_debug_mask {
+    ( $mask:expr, $log:expr, $($arg:tt)* ) => {
+        let log_level = unsafe { (*$log).log_level };
+        if log_level & $mask as usize != 0 {
+            let level = $mask as $crate::ffi::ngx_uint_t;
+            let fmt = ::std::ffi::CString::new("%s").unwrap();
+            let c_message = ::std::ffi::CString::new(format!($($arg)*)).unwrap();
+            unsafe {
+                $crate::ffi::ngx_log_error_core(level, $log, 0, fmt.as_ptr(), c_message.as_ptr());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Proposed changes

- minimal bindings for events (nginx_event_t and company) ([see example use here](https://github.com/nginxinc/nginx-retry/blob/35690eb85e56440427874b604fab6c6800ca4026/src/retry.rs#L141))
- getters for request status and subrequest depth
- cycle count increment
- flags as argument to subrequest
- subrequest can accept a custom data ([see example use here](https://github.com/nginxinc/nginx-retry/blob/35690eb85e56440427874b604fab6c6800ca4026/src/retry.rs#L178))
- do not automatically nuke the subrequest body. that should be up to the caller.

Testing
- Original testing against [nginx-retry](https://github.com/nginxinc/ngx-rust/pull/github.com/nginxinc/nginx-retry)

