### PR TITLE
feat: unsafe updates for raw pointer arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "ngx"
-version = "0.3.0-beta"
+version = "0.4.0-beta"
 dependencies = [
  "nginx-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "ngx"
-version = "0.3.0-beta"
+version = "0.4.0-beta"
 edition = "2021"
 autoexamples = false
 categories = ["api-bindings", "network-programming"]

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -193,12 +193,12 @@ impl Request {
 
     pub fn add_header_in(&mut self, key: &str, value: &str) -> Option<()> {
         let table: *mut ngx_table_elt_t = unsafe { ngx_list_push(&mut self.0.headers_in.headers) as _ };
-        add_to_ngx_table(table, self.0.pool, key, value)
+        unsafe { add_to_ngx_table(table, self.0.pool, key, value) }
     }
 
     pub fn add_header_out(&mut self, key: &str, value: &str) -> Option<()> {
         let table: *mut ngx_table_elt_t = unsafe { ngx_list_push(&mut self.0.headers_out.headers) as _ };
-        add_to_ngx_table(table, self.0.pool, key, value)
+        unsafe { add_to_ngx_table(table, self.0.pool, key, value) }
     }
 
     /// Set response body [Content-Length].
@@ -250,7 +250,7 @@ impl Request {
     /// Perform internal redirect to a location
     pub fn internal_redirect(&self, location: &str) -> Status {
         assert!(!location.is_empty(), "uri location is empty");
-        let uri_ptr = &mut ngx_str_t::from_str(self.0.pool, location) as *mut _;
+        let uri_ptr = unsafe { &mut ngx_str_t::from_str(self.0.pool, location) as *mut _ };
 
         // FIXME: check status of ngx_http_named_location or ngx_http_internal_redirect
         if location.starts_with('@') {
@@ -276,7 +276,7 @@ impl Request {
         module: &ngx_module_t,
         post_callback: unsafe extern "C" fn(*mut ngx_http_request_t, *mut c_void, ngx_int_t) -> ngx_int_t,
     ) -> Status {
-        let uri_ptr = &mut ngx_str_t::from_str(self.0.pool, uri) as *mut _;
+        let uri_ptr = unsafe { &mut ngx_str_t::from_str(self.0.pool, uri) as *mut _ };
         // -------------
         // allocate memory and set values for ngx_http_post_subrequest_t
         let sub_ptr = self.pool().alloc(std::mem::size_of::<ngx_http_post_subrequest_t>());


### PR DESCRIPTION
Dereferencing raw pointers is inherently unsafe. To satisfy clippy these functions and their callers require an unsafe indicator.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X ] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [X ] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [X ] I have added tests (when possible) that prove my fix is effective or that my feature works
- [X ] I have checked that all unit tests pass after adding my changes
- [X ] I have updated necessary documentation
- [X ] I have rebased my branch onto master
- [X ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
