### PR TITLE
fix: check user_agent for null

### DIFF
--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -185,8 +185,12 @@ impl Request {
     /// Client HTTP [User-Agent].
     ///
     /// [User-Agent]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
-    pub fn user_agent(&self) -> &NgxStr {
-        unsafe { NgxStr::from_ngx_str((*self.0.headers_in.user_agent).value) }
+    pub fn user_agent(&self) -> Option<&NgxStr> {
+        if !self.0.headers_in.user_agent.is_null() {
+            unsafe { Some(NgxStr::from_ngx_str((*self.0.headers_in.user_agent).value)) }
+        } else {
+            None
+        }
     }
 
     /// Set HTTP status of response.


### PR DESCRIPTION
### Proposed changes
When a client sends a request without a `user-agent` header (curl -H "user-agent:") then `pub fn user_agent(&self)` would crash.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [ ] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ ] I have added tests (when possible) that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [ ] I have rebased my branch onto master
- [ ] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
