### PR TITLE
fix: zlib update to 1.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ In short, this SDK allows writing NGINX modules using the Rust language.
 
 NGINX modules can be built against a particular version of NGINX. The following environment variables can be used to specify a particular version of NGINX or an NGINX dependency:
 
-* `ZLIB_VERSION` (default 1.3) -
+* `ZLIB_VERSION` (default 1.3.1) -
 * `PCRE2_VERSION` (default 10.42)
 * `OPENSSL_VERSION` (default 3.0.7)
 * `NGX_VERSION` (default 1.23.3) - NGINX OSS version

--- a/nginx-sys/build.rs
+++ b/nginx-sys/build.rs
@@ -15,7 +15,7 @@ use tar::Archive;
 use which::which;
 
 /// The default version of zlib to use if the `ZLIB_VERSION` environment variable is not present
-const ZLIB_DEFAULT_VERSION: &str = "1.3";
+const ZLIB_DEFAULT_VERSION: &str = "1.3.1";
 const ZLIB_GPG_SERVER_AND_KEY_ID: (&str, &str) = ("keyserver.ubuntu.com", "783FCD8E58BCAFBA");
 const ZLIB_DOWNLOAD_URL_PREFIX: &str = "https://www.zlib.net";
 /// The default version of pcre2 to use if the `PCRE2_VERSION` environment variable is not present


### PR DESCRIPTION
The previous 1.3 link is dead. 1.3.1 was released on Jan 22, 2024.