### PR TITLE
fix: use std::ffi::c_char instead of platform specific int

### DIFF
--- a/examples/upstream.rs
+++ b/examples/upstream.rs
@@ -250,7 +250,7 @@ unsafe extern "C" fn ngx_http_upstream_init_custom(
             NGX_LOG_EMERG as usize,
             cf,
             0,
-            "CUSTOM UPSTREAM no upstream srv_conf".as_bytes().as_ptr() as *const Ptr,
+            "CUSTOM UPSTREAM no upstream srv_conf".as_bytes().as_ptr() as *const c_char,
         );
         return isize::from(Status::NGX_ERROR);
     }
@@ -266,7 +266,7 @@ unsafe extern "C" fn ngx_http_upstream_init_custom(
             NGX_LOG_EMERG as usize,
             cf,
             0,
-            "CUSTOM UPSTREAM failed calling init_upstream".as_bytes().as_ptr() as *const Ptr,
+            "CUSTOM UPSTREAM failed calling init_upstream".as_bytes().as_ptr() as *const c_char,
         );
         return isize::from(Status::NGX_ERROR);
     }
@@ -299,11 +299,11 @@ unsafe extern "C" fn ngx_http_upstream_commands_set_custom(
                 NGX_LOG_EMERG as usize,
                 cf,
                 0,
-                "invalid value \"%V\" in \"%V\" directive".as_bytes().as_ptr() as *const Ptr,
+                "invalid value \"%V\" in \"%V\" directive".as_bytes().as_ptr() as *const c_char,
                 value[1],
                 &(*cmd).name,
             );
-            return usize::MAX as *mut Ptr;
+            return usize::MAX as *mut c_char;
         }
         ccf.max = n as u32;
     }
@@ -344,7 +344,7 @@ impl HTTPModule for Module {
                 0,
                 "CUSTOM UPSTREAM could not allocate memory for config"
                     .as_bytes()
-                    .as_ptr() as *const Ptr,
+                    .as_ptr() as *const c_char,
             );
             return std::ptr::null_mut();
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,12 +63,6 @@ pub mod log;
 #[macro_export]
 macro_rules! ngx_modules {
     ($( $mod:ident ),+) => {
-        #[cfg(target_arch = "aarch64")]
-        type Ptr = u8;
-
-        #[cfg(target_arch = "x86_64")]
-        type Ptr = i8;
-
         #[no_mangle]
         pub static mut ngx_modules: [*const ngx_module_t; $crate::count!($( $mod, )+) + 1] = [
             $( unsafe { &$mod } as *const ngx_module_t, )+
@@ -77,7 +71,7 @@ macro_rules! ngx_modules {
 
         #[no_mangle]
         pub static mut ngx_module_names: [*const c_char; $crate::count!($( $mod, )+) + 1] = [
-            $( concat!(stringify!($mod), "\0").as_ptr() as *const Ptr, )+
+            $( concat!(stringify!($mod), "\0").as_ptr() as *const c_char, )+
             std::ptr::null()
         ];
 


### PR DESCRIPTION
### Proposed changes
This change reverts a previous change that did platform detection and set a type correspondingly to u8 or i8. By using std::ffi::c_char we get a portable way to do the same thing.

This PR fixes a shortcoming with the change in commit: d66f3418d64a4acf18d6b9139db89cd0ec775690

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [X] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [X] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [X] I have added tests (when possible) that prove my fix is effective or that my feature works
- [X] I have checked that all unit tests pass after adding my changes
- [X] I have updated necessary documentation
- [X] I have rebased my branch onto master
- [X] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
