### PR TITLE
feat: build script support earlier Nginx version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ In short, this SDK allows writing NGINX modules using the Rust language.
 NGINX modules can be built against a particular version of NGINX. The following environment variables can be used to specify a particular version of NGINX or an NGINX dependency:
 
 * `ZLIB_VERSION` (default 1.3.1) -
-* `PCRE2_VERSION` (default 10.42)
-* `OPENSSL_VERSION` (default 3.2.1)
+* `PCRE2_VERSION` (default 10.42 for NGINX 1.22.0 and later, or 8.45 for earlier)
+* `OPENSSL_VERSION` (default 3.2.1 for NGINX 1.22.0 and later, or 1.1.1w for earlier)
 * `NGX_VERSION` (default 1.24.0) - NGINX OSS version
 * `NGX_DEBUG` (default to false)-  if set to true, then will compile NGINX `--with-debug` option
 

--- a/nginx-sys/build.rs
+++ b/nginx-sys/build.rs
@@ -253,14 +253,14 @@ fn all_archives() -> Vec<(String, String)> {
         }
         .into()
     });
-    fn easy_make_url_pair(tar_url: String, pgp_ext: &str) -> (String, String) {
+    fn url_pair(tar_url: String, pgp_ext: &str) -> (String, String) {
         (tar_url.clone(), format!("{tar_url}.{pgp_ext}"))
     }
     vec![
-        easy_make_url_pair(zlib_archive_url(&zlib_version), "asc"),
-        easy_make_url_pair(pcre_archive_url(&pcre_version), "sig"),
-        easy_make_url_pair(openssl_archive_url(&openssl_version), "asc"),
-        easy_make_url_pair(nginx_archive_url(&ngx_version), "asc"),
+        url_pair(zlib_archive_url(&zlib_version), "asc"),
+        url_pair(pcre_archive_url(&pcre_version), "sig"),
+        url_pair(openssl_archive_url(&openssl_version), "asc"),
+        url_pair(nginx_archive_url(&ngx_version), "asc"),
     ]
 }
 

--- a/nginx-sys/build.rs
+++ b/nginx-sys/build.rs
@@ -232,11 +232,11 @@ fn nginx_archive_url(version: &String) -> String {
 fn all_archives() -> Vec<(String, String)> {
     let ngx_version = env::var("NGX_VERSION").unwrap_or_else(|_| NGX_DEFAULT_VERSION.into());
     let zlib_version = env::var("ZLIB_VERSION").unwrap_or_else(|_| ZLIB_DEFAULT_VERSION.into());
-    // keep env name `PCRE2_VERSION` for compat
-    // Nginx had started supporting pcre2 and openssl3 since 1.22.0
+    // While Nginx 1.22.0 and later support pcre2 and openssl3, earlier ones only support pcre1 and openssl1. Here provides the appropriate (and as latest as possible) versions of these two dependencies as default, switching `***[major_version]_DEFAULT_VERSION` based on `is_after_1_22`. This facilitates to compile backport versions targeted for Nginx ealier than 1.22.0, which are still used in LTS releases of major Linux distributions.
     let ngx_version_vec: Vec<i16> = ngx_version.split('.').map(|s| s.parse().unwrap_or(-1)).collect();
     let is_after_1_22 = (ngx_version_vec.len() >= 2)
         && (ngx_version_vec[0] > 1 || (ngx_version_vec[0] == 1 && ngx_version_vec[1] >= 22));
+    // keep env name `PCRE2_VERSION` for compat
     let pcre_version = env::var("PCRE2_VERSION").unwrap_or_else(|_| {
         if is_after_1_22 {
             PCRE2_DEFAULT_VERSION

--- a/nginx-sys/build.rs
+++ b/nginx-sys/build.rs
@@ -48,11 +48,13 @@ const NGX_DEFAULT_VERSION: &str = "1.24.0";
 
 /// Key 1: Konstantin Pavlov's public key. For Nginx 1.25.3 and earlier
 /// Key 2: Sergey Kandaurov's public key. For Nginx 1.25.4
+/// Key 3: Maxim Dounin's public key. At least used for Nginx 1.18.0
 const NGX_GPG_SERVER_AND_KEY_IDS: (&str, &str) = (
     UBUNTU_KEYSEVER,
     "\
 13C82A63B603576156E30A4EA0EA981B66B0D967 \
-D6786CE303D9A9022998DC6CC8464D549AF75C0A",
+D6786CE303D9A9022998DC6CC8464D549AF75C0A \
+B0F4253373F8F6F510D42178520A9993A1C052F8",
 );
 
 const NGX_DOWNLOAD_URL_PREFIX: &str = "https://nginx.org/download";

--- a/nginx-sys/build.rs
+++ b/nginx-sys/build.rs
@@ -217,7 +217,12 @@ fn pcre2_archive_url() -> String {
 
 fn openssl_archive_url() -> String {
     let version = env::var("OPENSSL_VERSION").unwrap_or_else(|_| OPENSSL_DEFAULT_VERSION.to_string());
-    format!("{OPENSSL_DOWNLOAD_URL_PREFIX}/openssl-{version}/openssl-{version}.tar.gz")
+    if version.starts_with("1.1.1") {
+        let version_hyphened = version.replace(".", "_");
+        format!("{OPENSSL_DOWNLOAD_URL_PREFIX}/OpenSSL_{version_hyphened}/openssl-{version}.tar.gz")
+    } else {
+        format!("{OPENSSL_DOWNLOAD_URL_PREFIX}/openssl-{version}/openssl-{version}.tar.gz")
+    }
 }
 
 fn nginx_archive_url() -> String {


### PR DESCRIPTION
### Proposed changes

This PR enforces the build script of `nginx-sys` to download and use earlier versions of Nginx and its dependencies. This enables to build backports version targeted to LTS releases of Linux distributions. (ex. Ubuntu 22.04LTS provides a patched version of Nginx 1.18.0.)

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have added tests (when possible) that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
