### PR TITLE
fix: remove shared ref to static mut

### DIFF
--- a/examples/async.rs
+++ b/examples/async.rs
@@ -7,9 +7,8 @@ use ngx::ffi::{
 use ngx::http::MergeConfigError;
 use ngx::{core, core::Status, http, http::HTTPModule};
 use ngx::{http_request_handler, ngx_log_debug_http, ngx_modules, ngx_null_command, ngx_string};
-use std::borrow::Borrow;
 use std::os::raw::{c_char, c_void};
-use std::ptr::addr_of_mut;
+use std::ptr::{addr_of, addr_of_mut};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::time::Instant;
@@ -23,7 +22,7 @@ impl http::HTTPModule for Module {
     type LocConf = ModuleConfig;
 
     unsafe extern "C" fn postconfiguration(cf: *mut ngx_conf_t) -> ngx_int_t {
-        let cmcf = http::ngx_http_conf_get_module_main_conf(cf, ngx_http_core_module.borrow());
+        let cmcf = http::ngx_http_conf_get_module_main_conf(cf, &*addr_of!(ngx_http_core_module));
 
         let h = ngx_array_push(&mut (*cmcf).phases[ngx_http_phases_NGX_HTTP_ACCESS_PHASE as usize].handlers)
             as *mut ngx_http_handler_pt;
@@ -164,7 +163,7 @@ unsafe fn post_event(event: *mut ngx_event_t, queue: *mut ngx_queue_s) {
 }
 
 http_request_handler!(async_access_handler, |request: &mut http::Request| {
-    let co = unsafe { request.get_module_loc_conf::<ModuleConfig>(ngx_http_async_module.borrow()) };
+    let co = unsafe { request.get_module_loc_conf::<ModuleConfig>(&*addr_of!(ngx_http_async_module)) };
     let co = co.expect("module config is none");
     if !co.enable {
         return core::Status::NGX_DECLINED;

--- a/examples/awssig.rs
+++ b/examples/awssig.rs
@@ -7,6 +7,7 @@ use ngx::ffi::{
 };
 use ngx::{core, core::Status, http::*};
 use ngx::{http_request_handler, ngx_log_debug_http, ngx_modules, ngx_null_command, ngx_string};
+use std::borrow::Borrow;
 use std::os::raw::{c_char, c_void};
 
 struct Module;
@@ -17,7 +18,7 @@ impl HTTPModule for Module {
     type LocConf = ModuleConfig;
 
     unsafe extern "C" fn postconfiguration(cf: *mut ngx_conf_t) -> ngx_int_t {
-        let cmcf = ngx_http_conf_get_module_main_conf(cf, &ngx_http_core_module);
+        let cmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_core_module.borrow());
 
         let h = ngx_array_push(&mut (*cmcf).phases[ngx_http_phases_NGX_HTTP_PRECONTENT_PHASE as usize].handlers)
             as *mut ngx_http_handler_pt;
@@ -269,7 +270,7 @@ extern "C" fn ngx_http_awssigv4_commands_set_s3_endpoint(
 
 http_request_handler!(awssigv4_header_handler, |request: &mut Request| {
     // get Module Config from request
-    let conf = unsafe { request.get_module_loc_conf::<ModuleConfig>(&ngx_http_awssigv4_module) };
+    let conf = unsafe { request.get_module_loc_conf::<ModuleConfig>(ngx_http_awssigv4_module.borrow()) };
     let conf = conf.unwrap();
     ngx_log_debug_http!(request, "AWS signature V4 module {}", {
         if conf.enable {

--- a/examples/awssig.rs
+++ b/examples/awssig.rs
@@ -7,8 +7,8 @@ use ngx::ffi::{
 };
 use ngx::{core, core::Status, http::*};
 use ngx::{http_request_handler, ngx_log_debug_http, ngx_modules, ngx_null_command, ngx_string};
-use std::borrow::Borrow;
 use std::os::raw::{c_char, c_void};
+use std::ptr::addr_of;
 
 struct Module;
 
@@ -18,7 +18,7 @@ impl HTTPModule for Module {
     type LocConf = ModuleConfig;
 
     unsafe extern "C" fn postconfiguration(cf: *mut ngx_conf_t) -> ngx_int_t {
-        let cmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_core_module.borrow());
+        let cmcf = ngx_http_conf_get_module_main_conf(cf, &*addr_of!(ngx_http_core_module));
 
         let h = ngx_array_push(&mut (*cmcf).phases[ngx_http_phases_NGX_HTTP_PRECONTENT_PHASE as usize].handlers)
             as *mut ngx_http_handler_pt;
@@ -270,7 +270,7 @@ extern "C" fn ngx_http_awssigv4_commands_set_s3_endpoint(
 
 http_request_handler!(awssigv4_header_handler, |request: &mut Request| {
     // get Module Config from request
-    let conf = unsafe { request.get_module_loc_conf::<ModuleConfig>(ngx_http_awssigv4_module.borrow()) };
+    let conf = unsafe { request.get_module_loc_conf::<ModuleConfig>(&*addr_of!(ngx_http_awssigv4_module)) };
     let conf = conf.unwrap();
     ngx_log_debug_http!(request, "AWS signature V4 module {}", {
         if conf.enable {

--- a/examples/curl.rs
+++ b/examples/curl.rs
@@ -7,6 +7,7 @@ use ngx::ffi::{
 use ngx::http::MergeConfigError;
 use ngx::{core, core::Status, http, http::HTTPModule};
 use ngx::{http_request_handler, ngx_log_debug_http, ngx_modules, ngx_null_command, ngx_string};
+use std::borrow::Borrow;
 use std::os::raw::{c_char, c_void};
 
 struct Module;
@@ -17,7 +18,7 @@ impl http::HTTPModule for Module {
     type LocConf = ModuleConfig;
 
     unsafe extern "C" fn postconfiguration(cf: *mut ngx_conf_t) -> ngx_int_t {
-        let cmcf = http::ngx_http_conf_get_module_main_conf(cf, &ngx_http_core_module);
+        let cmcf = http::ngx_http_conf_get_module_main_conf(cf, ngx_http_core_module.borrow());
 
         let h = ngx_array_push(&mut (*cmcf).phases[ngx_http_phases_NGX_HTTP_ACCESS_PHASE as usize].handlers)
             as *mut ngx_http_handler_pt;
@@ -104,7 +105,7 @@ impl http::Merge for ModuleConfig {
 }
 
 http_request_handler!(curl_access_handler, |request: &mut http::Request| {
-    let co = unsafe { request.get_module_loc_conf::<ModuleConfig>(&ngx_http_curl_module) };
+    let co = unsafe { request.get_module_loc_conf::<ModuleConfig>(ngx_http_curl_module.borrow()) };
     let co = co.expect("module config is none");
 
     ngx_log_debug_http!(request, "curl module enabled: {}", co.enable);

--- a/examples/upstream.rs
+++ b/examples/upstream.rs
@@ -25,6 +25,7 @@ use ngx::{
     ngx_log_debug_http, ngx_log_debug_mask, ngx_modules, ngx_null_command, ngx_string,
 };
 use std::{
+    borrow::Borrow,
     mem,
     os::raw::{c_char, c_void},
     slice,
@@ -152,7 +153,7 @@ http_upstream_init_peer_pt!(
         }
 
         let maybe_conf: Option<*const SrvConfig> =
-            unsafe { ngx_http_conf_upstream_srv_conf_immutable(us, &ngx_http_upstream_custom_module) };
+            unsafe { ngx_http_conf_upstream_srv_conf_immutable(us, ngx_http_upstream_custom_module.borrow()) };
         if maybe_conf.is_none() {
             return Status::NGX_ERROR;
         }
@@ -244,7 +245,7 @@ unsafe extern "C" fn ngx_http_upstream_init_custom(
     ngx_log_debug_mask!(DebugMask::Http, (*cf).log, "CUSTOM UPSTREAM peer init_upstream");
 
     let maybe_conf: Option<*mut SrvConfig> =
-        ngx_http_conf_upstream_srv_conf_mutable(us, &ngx_http_upstream_custom_module);
+        ngx_http_conf_upstream_srv_conf_mutable(us, ngx_http_upstream_custom_module.borrow());
     if maybe_conf.is_none() {
         ngx_conf_log_error(
             NGX_LOG_EMERG as usize,
@@ -309,7 +310,7 @@ unsafe extern "C" fn ngx_http_upstream_commands_set_custom(
     }
 
     let uscf: *mut ngx_http_upstream_srv_conf_t =
-        ngx_http_conf_get_module_srv_conf(cf, &ngx_http_upstream_module) as *mut ngx_http_upstream_srv_conf_t;
+        ngx_http_conf_get_module_srv_conf(cf, ngx_http_upstream_module.borrow()) as *mut ngx_http_upstream_srv_conf_t;
 
     ccf.original_init_upstream = if (*uscf).peer.init_upstream.is_some() {
         (*uscf).peer.init_upstream

--- a/examples/upstream.rs
+++ b/examples/upstream.rs
@@ -25,9 +25,9 @@ use ngx::{
     ngx_log_debug_http, ngx_log_debug_mask, ngx_modules, ngx_null_command, ngx_string,
 };
 use std::{
-    borrow::Borrow,
     mem,
     os::raw::{c_char, c_void},
+    ptr::addr_of,
     slice,
 };
 
@@ -153,7 +153,7 @@ http_upstream_init_peer_pt!(
         }
 
         let maybe_conf: Option<*const SrvConfig> =
-            unsafe { ngx_http_conf_upstream_srv_conf_immutable(us, ngx_http_upstream_custom_module.borrow()) };
+            unsafe { ngx_http_conf_upstream_srv_conf_immutable(us, &*addr_of!(ngx_http_upstream_custom_module)) };
         if maybe_conf.is_none() {
             return Status::NGX_ERROR;
         }
@@ -245,7 +245,7 @@ unsafe extern "C" fn ngx_http_upstream_init_custom(
     ngx_log_debug_mask!(DebugMask::Http, (*cf).log, "CUSTOM UPSTREAM peer init_upstream");
 
     let maybe_conf: Option<*mut SrvConfig> =
-        ngx_http_conf_upstream_srv_conf_mutable(us, ngx_http_upstream_custom_module.borrow());
+        ngx_http_conf_upstream_srv_conf_mutable(us, &*addr_of!(ngx_http_upstream_custom_module));
     if maybe_conf.is_none() {
         ngx_conf_log_error(
             NGX_LOG_EMERG as usize,
@@ -310,7 +310,8 @@ unsafe extern "C" fn ngx_http_upstream_commands_set_custom(
     }
 
     let uscf: *mut ngx_http_upstream_srv_conf_t =
-        ngx_http_conf_get_module_srv_conf(cf, ngx_http_upstream_module.borrow()) as *mut ngx_http_upstream_srv_conf_t;
+        ngx_http_conf_get_module_srv_conf(cf, &*addr_of!(ngx_http_upstream_module))
+            as *mut ngx_http_upstream_srv_conf_t;
 
     ccf.original_init_upstream = if (*uscf).peer.init_upstream.is_some() {
         (*uscf).peer.init_upstream


### PR DESCRIPTION
### Proposed changes

This PR removes shared references to mutable statics, which is announced to be treated as hard error in 2024 edition.
Link to the issue: https://github.com/rust-lang/rust/issues/114447
While the compiler suggests to use `addr_of!()` or `addr_of_mut!()`, In most cases we use `borrow()` because we need not raw pointers but references.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have added tests (when possible) that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
