### PR TITLE
fix: add required pubkey for 1.25.5

### DIFF
--- a/nginx-sys/build.rs
+++ b/nginx-sys/build.rs
@@ -52,12 +52,14 @@ const NGX_DEFAULT_VERSION: &str = "1.24.0";
 /// Key 1: Konstantin Pavlov's public key. For Nginx 1.25.3 and earlier
 /// Key 2: Sergey Kandaurov's public key. For Nginx 1.25.4
 /// Key 3: Maxim Dounin's public key. At least used for Nginx 1.18.0
+/// Key 4: Roman Arutyunyan's public key. For Nginx 1.25.5
 const NGX_GPG_SERVER_AND_KEY_IDS: (&str, &str) = (
     UBUNTU_KEYSEVER,
     "\
 13C82A63B603576156E30A4EA0EA981B66B0D967 \
 D6786CE303D9A9022998DC6CC8464D549AF75C0A \
-B0F4253373F8F6F510D42178520A9993A1C052F8",
+B0F4253373F8F6F510D42178520A9993A1C052F8 \
+43387825DDB1BB97EC36BA5D007C8D7C15D87369",
 );
 
 const NGX_DOWNLOAD_URL_PREFIX: &str = "https://nginx.org/download";


### PR DESCRIPTION
Roman's key is necessary to build for nginx 1.25.5.

You can verify the key is legitimate through:

```
wget https://nginx.org/download/nginx-1.25.5.tar.gz
wget https://nginx.org/download/nginx-1.25.5.tar.gz.asc
gpg --verify nginx-1.25.5.tar.gz.asc
```

It is also here: https://keyserver.ubuntu.com/pks/lookup?search=43387825DDB1BB97EC36BA5D007C8D7C15D87369&fingerprint=on&op=index

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have added tests (when possible) that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
