### PR TITLE
fix(sys): drop unnecessary flags from vendored build on Linux

### DIFF
--- a/nginx-sys/build/vendored.rs
+++ b/nginx-sys/build/vendored.rs
@@ -95,10 +95,8 @@ const NGX_BASE_MODULES: [&str; 20] = [
     "--with-threads",
 ];
 /// Additional configuration flags to use when building on Linux.
-const NGX_LINUX_ADDITIONAL_OPTS: [&str; 3] = [
+const NGX_LINUX_ADDITIONAL_OPTS: [&str; 1] = [
     "--with-file-aio",
-    "--with-cc-opt=-g -fstack-protector-strong -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fPIC",
-    "--with-ld-opt=-Wl,-Bsymbolic-functions -Wl,-z,relro -Wl,-z,now -Wl,--as-needed -pie",
 ];
 const ENV_VARS_TRIGGERING_RECOMPILE: [&str; 12] = [
     "DEBUG",


### PR DESCRIPTION
 - `-fPIC` is not propagated to PCRE2, causing a linker error on Fedora
 - `-Wp,-D_FORTIFY_SOURCE=2` conflicts with the compiler builtin default value on Ubuntu 24.04
 - The remaining flags are also not necessary for testing the modules, and the binary produced by nginx-sys/vendored is not meant to be used in production.

Fixes #80