### PR TITLE
Byte-oriented methods for `ngx_str_t`

### DIFF
--- a/examples/httporigdst.rs
+++ b/examples/httporigdst.rs
@@ -28,7 +28,7 @@ impl Default for NgxHttpOrigDstCtx {
 
 impl NgxHttpOrigDstCtx {
     pub fn save(&mut self, addr: &str, port: in_port_t, pool: &mut core::Pool) -> core::Status {
-        let addr_data = pool.alloc(addr.len());
+        let addr_data = pool.alloc_unaligned(addr.len());
         if addr_data.is_null() {
             return core::Status::NGX_ERROR;
         }
@@ -37,7 +37,7 @@ impl NgxHttpOrigDstCtx {
         self.orig_dst_addr.data = addr_data as *mut u8;
 
         let port_str = port.to_string();
-        let port_data = pool.alloc(port_str.len());
+        let port_data = pool.alloc_unaligned(port_str.len());
         if port_data.is_null() {
             return core::Status::NGX_ERROR;
         }

--- a/nginx-sys/src/lib.rs
+++ b/nginx-sys/src/lib.rs
@@ -162,7 +162,7 @@ impl ngx_str_t {
     pub unsafe fn from_string(pool: *mut ngx_pool_t, data: String) -> Self {
         ngx_str_t {
             data: str_to_uchar(pool, data.as_str()),
-            len: data.len() as _,
+            len: data.len(),
         }
     }
 
@@ -183,7 +183,7 @@ impl ngx_str_t {
     pub unsafe fn from_str(pool: *mut ngx_pool_t, data: &str) -> Self {
         ngx_str_t {
             data: str_to_uchar(pool, data),
-            len: data.len() as _,
+            len: data.len(),
         }
     }
 }
@@ -254,9 +254,9 @@ pub unsafe fn add_to_ngx_table(
     }
     table.as_mut().map(|table| {
         table.hash = 1;
-        table.key.len = key.len() as _;
+        table.key.len = key.len();
         table.key.data = str_to_uchar(pool, key);
-        table.value.len = value.len() as _;
+        table.value.len = value.len();
         table.value.data = str_to_uchar(pool, value);
         table.lowcase_key = str_to_uchar(pool, String::from(key).to_ascii_lowercase().as_str());
     })

--- a/nginx-sys/src/lib.rs
+++ b/nginx-sys/src/lib.rs
@@ -57,7 +57,7 @@ pub use bindings::*;
 /// * `data` - The string slice to convert to a raw pointer.
 ///
 /// # Safety
-/// This function is marked as unsafe because it involves raw pointer manipulation and direct memory allocation using `ngx_palloc`.
+/// This function is marked as unsafe because it involves raw pointer manipulation and direct memory allocation using `ngx_pnalloc`.
 ///
 /// # Returns
 /// A raw pointer (`*mut u_char`) to the allocated memory containing the converted string data.
@@ -69,7 +69,7 @@ pub use bindings::*;
 /// let ptr = str_to_uchar(pool, data);
 /// ```
 pub unsafe fn str_to_uchar(pool: *mut ngx_pool_t, data: &str) -> *mut u_char {
-    let ptr: *mut u_char = ngx_palloc(pool, data.len() as _) as _;
+    let ptr: *mut u_char = ngx_pnalloc(pool, data.len()) as _;
     copy_nonoverlapping(data.as_ptr(), ptr, data.len());
     ptr
 }

--- a/src/core/pool.rs
+++ b/src/core/pool.rs
@@ -85,6 +85,7 @@ impl Pool {
     }
 
     /// Allocates memory from the pool of the specified size.
+    /// The resulting pointer is aligned to a platform word size.
     ///
     /// Returns a raw pointer to the allocated memory.
     pub fn alloc(&mut self, size: usize) -> *mut c_void {
@@ -92,6 +93,7 @@ impl Pool {
     }
 
     /// Allocates memory for a type from the pool.
+    /// The resulting pointer is aligned to a platform word size.
     ///
     /// Returns a typed pointer to the allocated memory.
     pub fn alloc_type<T: Copy>(&mut self) -> *mut T {
@@ -99,6 +101,7 @@ impl Pool {
     }
 
     /// Allocates zeroed memory from the pool of the specified size.
+    /// The resulting pointer is aligned to a platform word size.
     ///
     /// Returns a raw pointer to the allocated memory.
     pub fn calloc(&mut self, size: usize) -> *mut c_void {
@@ -106,10 +109,25 @@ impl Pool {
     }
 
     /// Allocates zeroed memory for a type from the pool.
+    /// The resulting pointer is aligned to a platform word size.
     ///
     /// Returns a typed pointer to the allocated memory.
     pub fn calloc_type<T: Copy>(&mut self) -> *mut T {
         self.calloc(mem::size_of::<T>()) as *mut T
+    }
+
+    /// Allocates unaligned memory from the pool of the specified size.
+    ///
+    /// Returns a raw pointer to the allocated memory.
+    pub fn alloc_unaligned(&mut self, size: usize) -> *mut c_void {
+        unsafe { ngx_pnalloc(self.0, size) }
+    }
+
+    /// Allocates unaligned memory for a type from the pool.
+    ///
+    /// Returns a typed pointer to the allocated memory.
+    pub fn alloc_type_unaligned<T: Copy>(&mut self) -> *mut T {
+        self.alloc_unaligned(mem::size_of::<T>()) as *mut T
     }
 
     /// Allocates memory for a value of a specified type and adds a cleanup handler to the memory pool.


### PR DESCRIPTION
`ngx_str_t` likely does *not* contain UTF-8, so converting it from/to UTF-8 strings is expensive and useless. `from_bytes()` and `as_bytes()` should be a more appropriate interface.

At some point in the future I intend to drop the `String`/`&str` conversion methods, as these aren't safe.