### PR TITLE
chore: group and reorder import statements

### DIFF
--- a/examples/async.rs
+++ b/examples/async.rs
@@ -7,7 +7,7 @@ use ngx::ffi::{
 };
 use ngx::http::{self, HTTPModule, MergeConfigError};
 use ngx::{http_request_handler, ngx_log_debug_http, ngx_null_command, ngx_string};
-use std::os::raw::{c_char, c_void};
+use std::ffi::{c_char, c_void};
 use std::ptr::{addr_of, addr_of_mut};
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -1,3 +1,9 @@
+use std::ffi::{c_char, c_void};
+use std::ptr::{addr_of, addr_of_mut};
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+use std::time::Instant;
+
 use ngx::core;
 use ngx::ffi::{
     nginx_version, ngx_array_push, ngx_command_t, ngx_conf_t, ngx_cycle, ngx_event_t, ngx_http_core_module,
@@ -7,11 +13,6 @@ use ngx::ffi::{
 };
 use ngx::http::{self, HTTPModule, MergeConfigError};
 use ngx::{http_request_handler, ngx_log_debug_http, ngx_null_command, ngx_string};
-use std::ffi::{c_char, c_void};
-use std::ptr::{addr_of, addr_of_mut};
-use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
-use std::time::Instant;
 use tokio::runtime::Runtime;
 
 struct Module;

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -1,11 +1,11 @@
+use ngx::core;
 use ngx::ffi::{
     nginx_version, ngx_array_push, ngx_command_t, ngx_conf_t, ngx_cycle, ngx_event_t, ngx_http_core_module,
     ngx_http_core_run_phases, ngx_http_handler_pt, ngx_http_module_t, ngx_http_phases_NGX_HTTP_ACCESS_PHASE,
     ngx_http_request_t, ngx_int_t, ngx_module_t, ngx_posted_events, ngx_queue_s, ngx_str_t, ngx_uint_t, NGX_CONF_TAKE1,
     NGX_HTTP_LOC_CONF, NGX_HTTP_MODULE, NGX_RS_HTTP_LOC_CONF_OFFSET, NGX_RS_MODULE_SIGNATURE,
 };
-use ngx::http::MergeConfigError;
-use ngx::{core, core::Status, http, http::HTTPModule};
+use ngx::http::{self, HTTPModule, MergeConfigError};
 use ngx::{http_request_handler, ngx_log_debug_http, ngx_null_command, ngx_string};
 use std::os::raw::{c_char, c_void};
 use std::ptr::{addr_of, addr_of_mut};

--- a/examples/awssig.rs
+++ b/examples/awssig.rs
@@ -8,7 +8,7 @@ use ngx::ffi::{
 };
 use ngx::http::*;
 use ngx::{http_request_handler, ngx_log_debug_http, ngx_null_command, ngx_string};
-use std::os::raw::{c_char, c_void};
+use std::ffi::{c_char, c_void};
 use std::ptr::addr_of;
 
 struct Module;

--- a/examples/awssig.rs
+++ b/examples/awssig.rs
@@ -1,11 +1,12 @@
 use http::HeaderMap;
+use ngx::core;
 use ngx::ffi::{
     nginx_version, ngx_array_push, ngx_command_t, ngx_conf_t, ngx_http_core_module, ngx_http_handler_pt,
-    ngx_http_module_t, ngx_http_phases_NGX_HTTP_PRECONTENT_PHASE, ngx_http_request_t, ngx_int_t, ngx_module_t,
-    ngx_str_t, ngx_uint_t, NGX_CONF_TAKE1, NGX_HTTP_LOC_CONF, NGX_HTTP_MODULE, NGX_HTTP_SRV_CONF,
-    NGX_RS_HTTP_LOC_CONF_OFFSET, NGX_RS_MODULE_SIGNATURE,
+    ngx_http_module_t, ngx_http_phases_NGX_HTTP_PRECONTENT_PHASE, ngx_int_t, ngx_module_t, ngx_str_t, ngx_uint_t,
+    NGX_CONF_TAKE1, NGX_HTTP_LOC_CONF, NGX_HTTP_MODULE, NGX_HTTP_SRV_CONF, NGX_RS_HTTP_LOC_CONF_OFFSET,
+    NGX_RS_MODULE_SIGNATURE,
 };
-use ngx::{core, core::Status, http::*};
+use ngx::http::*;
 use ngx::{http_request_handler, ngx_log_debug_http, ngx_null_command, ngx_string};
 use std::os::raw::{c_char, c_void};
 use std::ptr::addr_of;

--- a/examples/awssig.rs
+++ b/examples/awssig.rs
@@ -1,3 +1,6 @@
+use std::ffi::{c_char, c_void};
+use std::ptr::addr_of;
+
 use http::HeaderMap;
 use ngx::core;
 use ngx::ffi::{
@@ -8,8 +11,6 @@ use ngx::ffi::{
 };
 use ngx::http::*;
 use ngx::{http_request_handler, ngx_log_debug_http, ngx_null_command, ngx_string};
-use std::ffi::{c_char, c_void};
-use std::ptr::addr_of;
 
 struct Module;
 

--- a/examples/curl.rs
+++ b/examples/curl.rs
@@ -1,3 +1,6 @@
+use std::ffi::{c_char, c_void};
+use std::ptr::addr_of;
+
 use ngx::core;
 use ngx::ffi::{
     nginx_version, ngx_array_push, ngx_command_t, ngx_conf_t, ngx_http_core_module, ngx_http_handler_pt,
@@ -6,8 +9,6 @@ use ngx::ffi::{
 };
 use ngx::http::{self, HTTPModule, MergeConfigError};
 use ngx::{http_request_handler, ngx_log_debug_http, ngx_null_command, ngx_string};
-use std::ffi::{c_char, c_void};
-use std::ptr::addr_of;
 
 struct Module;
 

--- a/examples/curl.rs
+++ b/examples/curl.rs
@@ -6,7 +6,7 @@ use ngx::ffi::{
 };
 use ngx::http::{self, HTTPModule, MergeConfigError};
 use ngx::{http_request_handler, ngx_log_debug_http, ngx_null_command, ngx_string};
-use std::os::raw::{c_char, c_void};
+use std::ffi::{c_char, c_void};
 use std::ptr::addr_of;
 
 struct Module;

--- a/examples/curl.rs
+++ b/examples/curl.rs
@@ -1,11 +1,10 @@
+use ngx::core;
 use ngx::ffi::{
     nginx_version, ngx_array_push, ngx_command_t, ngx_conf_t, ngx_http_core_module, ngx_http_handler_pt,
-    ngx_http_module_t, ngx_http_phases_NGX_HTTP_ACCESS_PHASE, ngx_http_request_t, ngx_int_t, ngx_module_t, ngx_str_t,
-    ngx_uint_t, NGX_CONF_TAKE1, NGX_HTTP_LOC_CONF, NGX_HTTP_MODULE, NGX_RS_HTTP_LOC_CONF_OFFSET,
-    NGX_RS_MODULE_SIGNATURE,
+    ngx_http_module_t, ngx_http_phases_NGX_HTTP_ACCESS_PHASE, ngx_int_t, ngx_module_t, ngx_str_t, ngx_uint_t,
+    NGX_CONF_TAKE1, NGX_HTTP_LOC_CONF, NGX_HTTP_MODULE, NGX_RS_HTTP_LOC_CONF_OFFSET, NGX_RS_MODULE_SIGNATURE,
 };
-use ngx::http::MergeConfigError;
-use ngx::{core, core::Status, http, http::HTTPModule};
+use ngx::http::{self, HTTPModule, MergeConfigError};
 use ngx::{http_request_handler, ngx_log_debug_http, ngx_null_command, ngx_string};
 use std::os::raw::{c_char, c_void};
 use std::ptr::addr_of;

--- a/examples/httporigdst.rs
+++ b/examples/httporigdst.rs
@@ -6,7 +6,7 @@ use ngx::ffi::{
 };
 use ngx::http::{self, HTTPModule};
 use ngx::{http_variable_get, ngx_http_null_variable, ngx_log_debug_http, ngx_null_string, ngx_string};
-use std::os::raw::{c_char, c_int, c_void};
+use std::ffi::{c_char, c_int, c_void};
 use std::ptr::addr_of;
 
 const IPV4_STRLEN: usize = INET_ADDRSTRLEN as usize;

--- a/examples/httporigdst.rs
+++ b/examples/httporigdst.rs
@@ -1,10 +1,10 @@
+use ngx::core;
 use ngx::ffi::{
     in_port_t, nginx_version, ngx_conf_t, ngx_connection_local_sockaddr, ngx_http_add_variable, ngx_http_module_t,
-    ngx_http_request_t, ngx_http_variable_t, ngx_inet_get_port, ngx_int_t, ngx_module_t, ngx_sock_ntop, ngx_str_t,
-    ngx_uint_t, ngx_variable_value_t, sockaddr, sockaddr_storage, INET_ADDRSTRLEN, NGX_HTTP_MODULE,
-    NGX_RS_MODULE_SIGNATURE,
+    ngx_http_variable_t, ngx_inet_get_port, ngx_int_t, ngx_module_t, ngx_sock_ntop, ngx_str_t, ngx_uint_t,
+    ngx_variable_value_t, sockaddr, sockaddr_storage, INET_ADDRSTRLEN, NGX_HTTP_MODULE, NGX_RS_MODULE_SIGNATURE,
 };
-use ngx::{core, core::Status, http, http::HTTPModule};
+use ngx::http::{self, HTTPModule};
 use ngx::{http_variable_get, ngx_http_null_variable, ngx_log_debug_http, ngx_null_string, ngx_string};
 use std::os::raw::{c_char, c_int, c_void};
 use std::ptr::addr_of;

--- a/examples/httporigdst.rs
+++ b/examples/httporigdst.rs
@@ -1,3 +1,6 @@
+use std::ffi::{c_char, c_int, c_void};
+use std::ptr::addr_of;
+
 use ngx::core;
 use ngx::ffi::{
     in_port_t, nginx_version, ngx_conf_t, ngx_connection_local_sockaddr, ngx_http_add_variable, ngx_http_module_t,
@@ -6,8 +9,6 @@ use ngx::ffi::{
 };
 use ngx::http::{self, HTTPModule};
 use ngx::{http_variable_get, ngx_http_null_variable, ngx_log_debug_http, ngx_null_string, ngx_string};
-use std::ffi::{c_char, c_int, c_void};
-use std::ptr::addr_of;
 
 const IPV4_STRLEN: usize = INET_ADDRSTRLEN as usize;
 

--- a/examples/upstream.rs
+++ b/examples/upstream.rs
@@ -6,30 +6,26 @@
  * The NGINX authors are grateful to @gabihodoroaga for their contributions
  * to the community at large.
  */
-use ngx::{
-    core::{Pool, Status},
-    ffi::{
-        nginx_version, ngx_atoi, ngx_command_t, ngx_conf_log_error, ngx_conf_t, ngx_connection_t,
-        ngx_event_free_peer_pt, ngx_event_get_peer_pt, ngx_http_module_t, ngx_http_upstream_init_peer_pt,
-        ngx_http_upstream_init_pt, ngx_http_upstream_init_round_robin, ngx_http_upstream_module,
-        ngx_http_upstream_srv_conf_t, ngx_http_upstream_t, ngx_int_t, ngx_module_t, ngx_peer_connection_t, ngx_str_t,
-        ngx_uint_t, NGX_CONF_NOARGS, NGX_CONF_TAKE1, NGX_CONF_UNSET, NGX_ERROR, NGX_HTTP_MODULE, NGX_HTTP_UPS_CONF,
-        NGX_LOG_EMERG, NGX_RS_HTTP_SRV_CONF_OFFSET, NGX_RS_MODULE_SIGNATURE,
-    },
-    http::{
-        ngx_http_conf_get_module_srv_conf, ngx_http_conf_upstream_srv_conf_immutable,
-        ngx_http_conf_upstream_srv_conf_mutable, HTTPModule, Merge, MergeConfigError, Request,
-    },
-    http_upstream_init_peer_pt,
-    log::DebugMask,
-    ngx_log_debug_http, ngx_log_debug_mask, ngx_null_command, ngx_string,
+use std::ffi::{c_char, c_void};
+use std::mem;
+use std::ptr::addr_of;
+use std::slice;
+
+use ngx::core::{Pool, Status};
+use ngx::ffi::{
+    nginx_version, ngx_atoi, ngx_command_t, ngx_conf_log_error, ngx_conf_t, ngx_connection_t, ngx_event_free_peer_pt,
+    ngx_event_get_peer_pt, ngx_http_module_t, ngx_http_upstream_init_peer_pt, ngx_http_upstream_init_pt,
+    ngx_http_upstream_init_round_robin, ngx_http_upstream_module, ngx_http_upstream_srv_conf_t, ngx_http_upstream_t,
+    ngx_int_t, ngx_module_t, ngx_peer_connection_t, ngx_str_t, ngx_uint_t, NGX_CONF_NOARGS, NGX_CONF_TAKE1,
+    NGX_CONF_UNSET, NGX_ERROR, NGX_HTTP_MODULE, NGX_HTTP_UPS_CONF, NGX_LOG_EMERG, NGX_RS_HTTP_SRV_CONF_OFFSET,
+    NGX_RS_MODULE_SIGNATURE,
 };
-use std::{
-    ffi::{c_char, c_void},
-    mem,
-    ptr::addr_of,
-    slice,
+use ngx::http::{
+    ngx_http_conf_get_module_srv_conf, ngx_http_conf_upstream_srv_conf_immutable,
+    ngx_http_conf_upstream_srv_conf_mutable, HTTPModule, Merge, MergeConfigError, Request,
 };
+use ngx::log::DebugMask;
+use ngx::{http_upstream_init_peer_pt, ngx_log_debug_http, ngx_log_debug_mask, ngx_null_command, ngx_string};
 
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]

--- a/examples/upstream.rs
+++ b/examples/upstream.rs
@@ -25,8 +25,8 @@ use ngx::{
     ngx_log_debug_http, ngx_log_debug_mask, ngx_null_command, ngx_string,
 };
 use std::{
+    ffi::{c_char, c_void},
     mem,
-    os::raw::{c_char, c_void},
     ptr::addr_of,
     slice,
 };

--- a/examples/upstream.rs
+++ b/examples/upstream.rs
@@ -10,11 +10,11 @@ use ngx::{
     core::{Pool, Status},
     ffi::{
         nginx_version, ngx_atoi, ngx_command_t, ngx_conf_log_error, ngx_conf_t, ngx_connection_t,
-        ngx_event_free_peer_pt, ngx_event_get_peer_pt, ngx_http_module_t, ngx_http_request_t,
-        ngx_http_upstream_init_peer_pt, ngx_http_upstream_init_pt, ngx_http_upstream_init_round_robin,
-        ngx_http_upstream_module, ngx_http_upstream_srv_conf_t, ngx_http_upstream_t, ngx_int_t, ngx_module_t,
-        ngx_peer_connection_t, ngx_str_t, ngx_uint_t, NGX_CONF_NOARGS, NGX_CONF_TAKE1, NGX_CONF_UNSET, NGX_ERROR,
-        NGX_HTTP_MODULE, NGX_HTTP_UPS_CONF, NGX_LOG_EMERG, NGX_RS_HTTP_SRV_CONF_OFFSET, NGX_RS_MODULE_SIGNATURE,
+        ngx_event_free_peer_pt, ngx_event_get_peer_pt, ngx_http_module_t, ngx_http_upstream_init_peer_pt,
+        ngx_http_upstream_init_pt, ngx_http_upstream_init_round_robin, ngx_http_upstream_module,
+        ngx_http_upstream_srv_conf_t, ngx_http_upstream_t, ngx_int_t, ngx_module_t, ngx_peer_connection_t, ngx_str_t,
+        ngx_uint_t, NGX_CONF_NOARGS, NGX_CONF_TAKE1, NGX_CONF_UNSET, NGX_ERROR, NGX_HTTP_MODULE, NGX_HTTP_UPS_CONF,
+        NGX_LOG_EMERG, NGX_RS_HTTP_SRV_CONF_OFFSET, NGX_RS_MODULE_SIGNATURE,
     },
     http::{
         ngx_http_conf_get_module_srv_conf, ngx_http_conf_upstream_srv_conf_immutable,

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
+# group_imports = "StdExternalCrate" # unstable
 max_width = 120

--- a/src/core/buffer.rs
+++ b/src/core/buffer.rs
@@ -1,6 +1,6 @@
-use crate::ffi::*;
-
 use std::slice;
+
+use crate::ffi::*;
 
 /// The `Buffer` trait provides methods for working with an nginx buffer (`ngx_buf_t`).
 pub trait Buffer {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -16,7 +16,7 @@ pub use string::*;
 #[macro_export]
 macro_rules! ngx_null_command {
     () => {
-        ngx_command_t {
+        $crate::ffi::ngx_command_t {
             name: $crate::ngx_null_string!(),
             type_: 0,
             set: None,
@@ -35,7 +35,7 @@ macro_rules! ngx_null_command {
 #[macro_export]
 macro_rules! ngx_http_null_variable {
     () => {
-        ngx_http_variable_t {
+        $crate::ffi::ngx_http_variable_t {
             name: $crate::ngx_null_string!(),
             set_handler: None,
             get_handler: None,
@@ -54,7 +54,7 @@ macro_rules! ngx_http_null_variable {
 #[macro_export]
 macro_rules! ngx_stream_null_variable {
     () => {
-        ngx_stream_variable_t {
+        $crate::ffi::ngx_stream_variable_t {
             name: $crate::ngx_null_string!(),
             set_handler: None,
             get_handler: None,

--- a/src/core/pool.rs
+++ b/src/core/pool.rs
@@ -1,7 +1,7 @@
 use crate::core::buffer::{Buffer, MemoryBuffer, TemporaryBuffer};
 use crate::ffi::*;
 
-use std::os::raw::c_void;
+use std::ffi::c_void;
 use std::{mem, ptr};
 
 /// Wrapper struct for an `ngx_pool_t` pointer, providing methods for working with memory pools.

--- a/src/core/pool.rs
+++ b/src/core/pool.rs
@@ -1,8 +1,8 @@
-use crate::core::buffer::{Buffer, MemoryBuffer, TemporaryBuffer};
-use crate::ffi::*;
-
 use std::ffi::c_void;
 use std::{mem, ptr};
+
+use crate::core::buffer::{Buffer, MemoryBuffer, TemporaryBuffer};
+use crate::ffi::*;
 
 /// Wrapper struct for an `ngx_pool_t` pointer, providing methods for working with memory pools.
 pub struct Pool(*mut ngx_pool_t);

--- a/src/core/status.rs
+++ b/src/core/status.rs
@@ -1,5 +1,6 @@
-use crate::ffi::*;
 use std::fmt;
+
+use crate::ffi::*;
 
 /// Status
 ///

--- a/src/core/string.rs
+++ b/src/core/string.rs
@@ -1,8 +1,8 @@
-use crate::ffi::*;
-
 use std::borrow::Cow;
 use std::slice;
 use std::str::{self, Utf8Error};
+
+use crate::ffi::*;
 
 /// Static string initializer for [`ngx_str_t`].
 ///

--- a/src/http/conf.rs
+++ b/src/http/conf.rs
@@ -1,6 +1,6 @@
 use crate::ffi::*;
 
-use std::os::raw::c_void;
+use std::ffi::c_void;
 
 /// # Safety
 ///

--- a/src/http/conf.rs
+++ b/src/http/conf.rs
@@ -1,6 +1,6 @@
-use crate::ffi::*;
-
 use std::ffi::c_void;
+
+use crate::ffi::*;
 
 /// # Safety
 ///

--- a/src/http/module.rs
+++ b/src/http/module.rs
@@ -2,8 +2,8 @@ use crate::core::NGX_CONF_ERROR;
 use crate::core::*;
 use crate::ffi::*;
 
-use core::ptr;
-use std::os::raw::{c_char, c_void};
+use std::ffi::{c_char, c_void};
+use std::ptr;
 
 /// MergeConfigError - configuration cannot be merged with levels above.
 #[derive(Debug)]

--- a/src/http/module.rs
+++ b/src/http/module.rs
@@ -1,9 +1,9 @@
+use std::ffi::{c_char, c_void};
+use std::ptr;
+
 use crate::core::NGX_CONF_ERROR;
 use crate::core::*;
 use crate::ffi::*;
-
-use std::ffi::{c_char, c_void};
-use std::ptr;
 
 /// MergeConfigError - configuration cannot be merged with levels above.
 #[derive(Debug)]

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -2,8 +2,8 @@ use crate::core::*;
 use crate::ffi::*;
 use crate::http::status::*;
 use crate::ngx_null_string;
+use std::ffi::c_void;
 use std::fmt;
-use std::os::raw::c_void;
 
 use std::error::Error;
 use std::str::FromStr;

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -1,12 +1,12 @@
+use std::error::Error;
+use std::ffi::c_void;
+use std::fmt;
+use std::str::FromStr;
+
 use crate::core::*;
 use crate::ffi::*;
 use crate::http::status::*;
 use crate::ngx_null_string;
-use std::ffi::c_void;
-use std::fmt;
-
-use std::error::Error;
-use std::str::FromStr;
 
 /// Define a static request handler.
 ///

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -15,8 +15,9 @@ use std::str::FromStr;
 macro_rules! http_request_handler {
     ( $name: ident, $handler: expr ) => {
         #[no_mangle]
-        extern "C" fn $name(r: *mut ngx_http_request_t) -> ngx_int_t {
-            let status: Status = $handler(unsafe { &mut $crate::http::Request::from_ngx_http_request(r) });
+        extern "C" fn $name(r: *mut $crate::ffi::ngx_http_request_t) -> $crate::ffi::ngx_int_t {
+            let status: $crate::core::Status =
+                $handler(unsafe { &mut $crate::http::Request::from_ngx_http_request(r) });
             status.0
         }
     };
@@ -29,7 +30,11 @@ macro_rules! http_request_handler {
 macro_rules! http_subrequest_handler {
     ( $name: ident, $handler: expr ) => {
         #[no_mangle]
-        unsafe extern "C" fn $name(r: *mut ngx_http_request_t, data: *mut c_void, rc: ngx_int_t) -> ngx_int_t {
+        unsafe extern "C" fn $name(
+            r: *mut $crate::ffi::ngx_http_request_t,
+            data: *mut ::std::ffi::c_void,
+            rc: $crate::ffi::ngx_int_t,
+        ) -> $crate::ffi::ngx_int_t {
             $handler(r, data, rc)
         }
     };
@@ -44,7 +49,11 @@ macro_rules! http_subrequest_handler {
 macro_rules! http_variable_set {
     ( $name: ident, $handler: expr ) => {
         #[no_mangle]
-        unsafe extern "C" fn $name(r: *mut ngx_http_request_t, v: *mut ngx_variable_value_t, data: usize) {
+        unsafe extern "C" fn $name(
+            r: *mut $crate::ffi::ngx_http_request_t,
+            v: *mut $crate::ffi::ngx_variable_value_t,
+            data: usize,
+        ) {
             $handler(
                 unsafe { &mut $crate::http::Request::from_ngx_http_request(r) },
                 v,
@@ -64,8 +73,12 @@ macro_rules! http_variable_set {
 macro_rules! http_variable_get {
     ( $name: ident, $handler: expr ) => {
         #[no_mangle]
-        unsafe extern "C" fn $name(r: *mut ngx_http_request_t, v: *mut ngx_variable_value_t, data: usize) -> ngx_int_t {
-            let status: Status = $handler(
+        unsafe extern "C" fn $name(
+            r: *mut $crate::ffi::ngx_http_request_t,
+            v: *mut $crate::ffi::ngx_variable_value_t,
+            data: usize,
+        ) -> $crate::ffi::ngx_int_t {
+            let status: $crate::core::Status = $handler(
                 unsafe { &mut $crate::http::Request::from_ngx_http_request(r) },
                 v,
                 data,

--- a/src/http/status.rs
+++ b/src/http/status.rs
@@ -1,7 +1,8 @@
-use crate::core::Status;
-use crate::ffi::*;
 use std::error::Error;
 use std::fmt;
+
+use crate::core::Status;
+use crate::ffi::*;
 
 /// Represents an HTTP status code.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/http/upstream.rs
+++ b/src/http/upstream.rs
@@ -13,8 +13,14 @@
 macro_rules! http_upstream_init_peer_pt {
     ( $name: ident, $handler: expr ) => {
         #[no_mangle]
-        extern "C" fn $name(r: *mut ngx_http_request_t, us: *mut ngx_http_upstream_srv_conf_t) -> ngx_int_t {
-            let status: Status = $handler(unsafe { &mut Request::from_ngx_http_request(r) }, us);
+        extern "C" fn $name(
+            r: *mut $crate::ffi::ngx_http_request_t,
+            us: *mut $crate::ffi::ngx_http_upstream_srv_conf_t,
+        ) -> $crate::ffi::ngx_int_t {
+            let status: $crate::core::Status = $handler(
+                unsafe { &mut $crate::http::Request::from_ngx_http_request(r) },
+                us,
+            );
             status.0
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,20 +64,20 @@ pub mod log;
 macro_rules! ngx_modules {
     ($( $mod:ident ),+) => {
         #[no_mangle]
-        pub static mut ngx_modules: [*const ngx_module_t; $crate::count!($( $mod, )+) + 1] = [
-            $( unsafe { &$mod } as *const ngx_module_t, )+
-            std::ptr::null()
+        pub static mut ngx_modules: [*const $crate::ffi::ngx_module_t; $crate::count!($( $mod, )+) + 1] = [
+            $( unsafe { &$mod } as *const $crate::ffi::ngx_module_t, )+
+            ::std::ptr::null()
         ];
 
         #[no_mangle]
-        pub static mut ngx_module_names: [*const c_char; $crate::count!($( $mod, )+) + 1] = [
-            $( concat!(stringify!($mod), "\0").as_ptr() as *const c_char, )+
-            std::ptr::null()
+        pub static mut ngx_module_names: [*const ::std::ffi::c_char; $crate::count!($( $mod, )+) + 1] = [
+            $( concat!(stringify!($mod), "\0").as_ptr() as *const ::std::ffi::c_char, )+
+            ::std::ptr::null()
         ];
 
         #[no_mangle]
-        pub static mut ngx_module_order: [*const c_char; 1] = [
-            std::ptr::null()
+        pub static mut ngx_module_order: [*const ::std::ffi::c_char; 1] = [
+            ::std::ptr::null()
         ];
     };
 }

--- a/tests/log_test.rs
+++ b/tests/log_test.rs
@@ -97,8 +97,9 @@ impl Nginx {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::env;
+
+    use super::*;
 
     const TEST_NGINX_CONFIG: &str = "tests/nginx.conf";
 


### PR DESCRIPTION
Non-functional change: reshuffle imports and ensure that the crate types don't leak from the exported macros.