### PR TITLE
Logging improvements

### DIFF
--- a/examples/upstream.rs
+++ b/examples/upstream.rs
@@ -13,19 +13,21 @@ use std::slice;
 
 use ngx::core::{Pool, Status};
 use ngx::ffi::{
-    nginx_version, ngx_atoi, ngx_command_t, ngx_conf_log_error, ngx_conf_t, ngx_connection_t, ngx_event_free_peer_pt,
+    nginx_version, ngx_atoi, ngx_command_t, ngx_conf_t, ngx_connection_t, ngx_event_free_peer_pt,
     ngx_event_get_peer_pt, ngx_http_module_t, ngx_http_upstream_init_peer_pt, ngx_http_upstream_init_pt,
     ngx_http_upstream_init_round_robin, ngx_http_upstream_module, ngx_http_upstream_srv_conf_t, ngx_http_upstream_t,
     ngx_int_t, ngx_module_t, ngx_peer_connection_t, ngx_str_t, ngx_uint_t, NGX_CONF_NOARGS, NGX_CONF_TAKE1,
-    NGX_CONF_UNSET, NGX_ERROR, NGX_HTTP_MODULE, NGX_HTTP_UPS_CONF, NGX_LOG_EMERG, NGX_RS_HTTP_SRV_CONF_OFFSET,
+    NGX_CONF_UNSET, NGX_ERROR, NGX_HTTP_MODULE, NGX_HTTP_UPS_CONF, NGX_RS_HTTP_SRV_CONF_OFFSET,
     NGX_RS_MODULE_SIGNATURE,
 };
 use ngx::http::{
     ngx_http_conf_get_module_srv_conf, ngx_http_conf_upstream_srv_conf_immutable,
     ngx_http_conf_upstream_srv_conf_mutable, HTTPModule, Merge, MergeConfigError, Request,
 };
-use ngx::log::DebugMask;
-use ngx::{http_upstream_init_peer_pt, ngx_log_debug_http, ngx_log_debug_mask, ngx_null_command, ngx_string};
+use ngx::log::{DebugMask, Level};
+use ngx::{
+    http_upstream_init_peer_pt, ngx_log_debug_http, ngx_log_debug_mask, ngx_log_error, ngx_null_command, ngx_string,
+};
 
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
@@ -247,12 +249,7 @@ unsafe extern "C" fn ngx_http_upstream_init_custom(
     let maybe_conf: Option<*mut SrvConfig> =
         ngx_http_conf_upstream_srv_conf_mutable(us, &*addr_of!(ngx_http_upstream_custom_module));
     if maybe_conf.is_none() {
-        ngx_conf_log_error(
-            NGX_LOG_EMERG as usize,
-            cf,
-            0,
-            "CUSTOM UPSTREAM no upstream srv_conf".as_bytes().as_ptr() as *const c_char,
-        );
+        ngx_log_error!(Level::Emerg, cf, "CUSTOM UPSTREAM no upstream srv_conf");
         return isize::from(Status::NGX_ERROR);
     }
     let hccf = maybe_conf.unwrap();
@@ -263,12 +260,7 @@ unsafe extern "C" fn ngx_http_upstream_init_custom(
 
     let init_upstream_ptr = (*hccf).original_init_upstream.unwrap();
     if init_upstream_ptr(cf, us) != Status::NGX_OK.into() {
-        ngx_conf_log_error(
-            NGX_LOG_EMERG as usize,
-            cf,
-            0,
-            "CUSTOM UPSTREAM failed calling init_upstream".as_bytes().as_ptr() as *const c_char,
-        );
+        ngx_log_error!(Level::Emerg, cf, "CUSTOM UPSTREAM failed calling init_upstream");
         return isize::from(Status::NGX_ERROR);
     }
 
@@ -296,13 +288,12 @@ unsafe extern "C" fn ngx_http_upstream_commands_set_custom(
         let value: &[ngx_str_t] = slice::from_raw_parts((*(*cf).args).elts as *const ngx_str_t, (*(*cf).args).nelts);
         let n = ngx_atoi(value[1].data, value[1].len);
         if n == (NGX_ERROR as isize) || n == 0 {
-            ngx_conf_log_error(
-                NGX_LOG_EMERG as usize,
+            ngx_log_error!(
+                Level::Emerg,
                 cf,
-                0,
-                "invalid value \"%V\" in \"%V\" directive".as_bytes().as_ptr() as *const c_char,
+                "invalid value \"{}\" in \"{}\" directive",
                 value[1],
-                &(*cmd).name,
+                &(*cmd).name
             );
             return usize::MAX as *mut c_char;
         }
@@ -340,14 +331,7 @@ impl HTTPModule for Module {
         let mut pool = Pool::from_ngx_pool((*cf).pool);
         let conf = pool.alloc_type::<SrvConfig>();
         if conf.is_null() {
-            ngx_conf_log_error(
-                NGX_LOG_EMERG as usize,
-                cf,
-                0,
-                "CUSTOM UPSTREAM could not allocate memory for config"
-                    .as_bytes()
-                    .as_ptr() as *const c_char,
-            );
+            ngx_log_error!(Level::Emerg, cf, "CUSTOM UPSTREAM could not allocate memory for config");
             return std::ptr::null_mut();
         }
 

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -106,6 +106,32 @@ impl<'a> From<&'a mut Request> for *mut ngx_http_request_t {
     }
 }
 
+impl crate::log::LogTarget for ngx_http_request_t {
+    #[inline]
+    fn debug_mask(&self) -> crate::log::DebugMask {
+        crate::log::DebugMask::Http
+    }
+
+    #[inline]
+    fn get_log(&self) -> *const ngx_log_t {
+        // SAFETY: request must have a connecton and connection must have log
+        unsafe { (*self.connection).log }
+    }
+}
+
+impl crate::log::LogTarget for Request {
+    #[inline]
+    fn debug_mask(&self) -> crate::log::DebugMask {
+        crate::log::DebugMask::Http
+    }
+
+    #[inline]
+    fn get_log(&self) -> *const ngx_log_t {
+        // SAFETY: request must have a connecton and connection must have log
+        unsafe { (*self.connection()).log }
+    }
+}
+
 impl Request {
     /// Create a [`Request`] from an [`ngx_http_request_t`].
     ///


### PR DESCRIPTION
WIP, because I want to set up CI tests of the example modules before merging any significant changes.
***

Log macros now accept any object that implements `LogTarget`, i.e. requests, events, `ngx_conf_t`, etc. Default mask for the `ngx_log_debug!` is set according to the object type.
With all the complexity added, the code still makes 1-2 allocations less than the original variant and gets completely inlined in the release builds.

A few tricky moments:
 * `LogTarget` trait is intentionally kept [object-safe](https://doc.rust-lang.org/reference/items/traits.html#object-safety), because one of the planned further steps is to offer integration with the [`log`](https://docs.rs/log) facade and that required type erasure via `dyn LogTarget` (to be reevaluated).
 * Log methods take pointers to make things work uniformly for pointer and reference arguments. I wish I knew a better way to handle that.
 * Log methods take const ptr to avoid creating a mutable borrow (or failing to compile because the target was already borrowed immutably). It may look suspicious, but in the end we have a pointer to `ngx_log_t` that comes from C, points to a writable memory, and doesn't have to satisfy the Rust memory model constraints (as described in the [`std::ptr::from_ref`](https://doc.rust-lang.org/stable/std/ptr/fn.from_ref.html)).

Fixes #47
Fixes #92 