### PR TITLE
add `std`,`alloc` feature flag to support `no_std` build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,16 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-nginx-sys = { path = "nginx-sys", version = "0.5.0"}
+nginx-sys = { path = "nginx-sys", default-features=false, version = "0.5.0"}
 
 [features]
-default = ["vendored"]
+default = ["vendored","std"]
+# Enables the components using memory allocation.
+# If no `std` flag, `alloc` crate is internally used instead. This flag is mainly for `no_std` build.
+alloc = []
+# Enables the components using `std` crate.
+# Currently the only difference to `alloc` flag is `std::error::Error` implementation.
+std = ["alloc"]
 # Build our own copy of the NGINX by default.
 # This could be disabled with `--no-default-features` to minimize the dependency tree
 # when building against an existing copy of the NGINX with the NGX_OBJS variable.

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,7 +12,7 @@ build = "../build.rs"
 
 [dependencies]
 nginx-sys = { path = "../nginx-sys/", default-features = false }
-ngx = { path = "../", default-features = false }
+ngx = { path = "../", default-features = false, features = ["std"] }
 
 [dev-dependencies]
 aws-sign-v4 = "0.3.0"

--- a/nginx-sys/build/main.rs
+++ b/nginx-sys/build/main.rs
@@ -97,6 +97,7 @@ fn generate_binding(nginx_build_dir: PathBuf) {
         .header("build/wrapper.h")
         .clang_args(clang_args)
         .layout_tests(false)
+        .use_core()
         .generate()
         .expect("Unable to generate bindings");
 

--- a/nginx-sys/src/lib.rs
+++ b/nginx-sys/src/lib.rs
@@ -1,9 +1,10 @@
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
+#![no_std]
 
-use std::fmt;
-use std::ptr::copy_nonoverlapping;
-use std::slice;
+use core::fmt;
+use core::ptr::copy_nonoverlapping;
+use core::slice;
 
 #[doc(hidden)]
 mod bindings {
@@ -104,7 +105,7 @@ impl ngx_str_t {
     /// # Returns
     /// A string slice (`&str`) representing the nginx string.
     pub fn to_str(&self) -> &str {
-        std::str::from_utf8(self.as_bytes()).unwrap()
+        core::str::from_utf8(self.as_bytes()).unwrap()
     }
 
     /// Create an `ngx_str_t` instance from a byte slice.
@@ -147,15 +148,6 @@ impl From<ngx_str_t> for &[u8] {
     }
 }
 
-impl TryFrom<ngx_str_t> for String {
-    type Error = std::string::FromUtf8Error;
-
-    fn try_from(s: ngx_str_t) -> Result<Self, Self::Error> {
-        let bytes: &[u8] = s.into();
-        String::from_utf8(bytes.into())
-    }
-}
-
 impl fmt::Display for ngx_str_t {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // The implementation is similar to an inlined `String::from_utf8_lossy`, with two
@@ -175,10 +167,10 @@ impl fmt::Display for ngx_str_t {
 }
 
 impl TryFrom<ngx_str_t> for &str {
-    type Error = std::str::Utf8Error;
+    type Error = core::str::Utf8Error;
 
     fn try_from(s: ngx_str_t) -> Result<Self, Self::Error> {
-        std::str::from_utf8(s.into())
+        core::str::from_utf8(s.into())
     }
 }
 
@@ -231,7 +223,8 @@ pub unsafe fn add_to_ngx_table(
 
 #[cfg(test)]
 mod tests {
-    use std::string::ToString;
+    extern crate alloc;
+    use alloc::string::ToString;
 
     use super::*;
 

--- a/src/core/buffer.rs
+++ b/src/core/buffer.rs
@@ -1,4 +1,4 @@
-use std::slice;
+use core::slice;
 
 use crate::ffi::*;
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -22,7 +22,7 @@ macro_rules! ngx_null_command {
             set: None,
             conf: 0,
             offset: 0,
-            post: ::std::ptr::null_mut(),
+            post: ::core::ptr::null_mut(),
         }
     };
 }

--- a/src/core/pool.rs
+++ b/src/core/pool.rs
@@ -1,5 +1,5 @@
-use std::ffi::c_void;
-use std::{mem, ptr};
+use core::ffi::c_void;
+use core::{mem, ptr};
 
 use crate::core::buffer::{Buffer, MemoryBuffer, TemporaryBuffer};
 use crate::ffi::*;

--- a/src/core/status.rs
+++ b/src/core/status.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use core::fmt;
 
 use crate::ffi::*;
 

--- a/src/core/string.rs
+++ b/src/core/string.rs
@@ -1,6 +1,10 @@
-use std::borrow::Cow;
-use std::slice;
-use std::str::{self, Utf8Error};
+use core::slice;
+use core::str::{self, Utf8Error};
+
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+use alloc::{borrow::Cow, string::String};
+#[cfg(feature = "std")]
+use std::{borrow::Cow, string::String};
 
 use crate::ffi::*;
 
@@ -27,7 +31,7 @@ macro_rules! ngx_null_string {
     () => {
         $crate::ffi::ngx_str_t {
             len: 0,
-            data: ::std::ptr::null_mut(),
+            data: ::core::ptr::null_mut(),
         }
     };
 }
@@ -64,6 +68,7 @@ impl NgxStr {
     /// Converts an [`NgxStr`] into a [`Cow<str>`], replacing invalid UTF-8 sequences.
     ///
     /// See [`String::from_utf8_lossy`].
+    #[cfg(feature = "alloc")]
     pub fn to_string_lossy(&self) -> Cow<str> {
         String::from_utf8_lossy(self.as_bytes())
     }

--- a/src/http/conf.rs
+++ b/src/http/conf.rs
@@ -1,4 +1,4 @@
-use std::ffi::c_void;
+use core::ffi::c_void;
 
 use crate::ffi::*;
 

--- a/src/http/module.rs
+++ b/src/http/module.rs
@@ -1,5 +1,6 @@
-use std::ffi::{c_char, c_void};
-use std::ptr;
+use core::ffi::{c_char, c_void};
+use core::fmt;
+use core::ptr;
 
 use crate::core::NGX_CONF_ERROR;
 use crate::core::*;
@@ -12,10 +13,11 @@ pub enum MergeConfigError {
     NoValue,
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for MergeConfigError {}
 
-impl std::fmt::Display for MergeConfigError {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl fmt::Display for MergeConfigError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         match self {
             MergeConfigError::NoValue => "no value".fmt(fmt),
         }

--- a/src/http/status.rs
+++ b/src/http/status.rs
@@ -25,7 +25,7 @@ impl InvalidHTTPStatusCode {
 
 impl fmt::Display for InvalidHTTPStatusCode {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("invalid status code".to_string().as_str())
+        f.write_str("invalid status code")
     }
 }
 

--- a/src/http/status.rs
+++ b/src/http/status.rs
@@ -1,5 +1,4 @@
-use std::error::Error;
-use std::fmt;
+use core::fmt;
 
 use crate::core::Status;
 use crate::ffi::*;
@@ -29,7 +28,8 @@ impl fmt::Display for InvalidHTTPStatusCode {
     }
 }
 
-impl Error for InvalidHTTPStatusCode {}
+#[cfg(feature = "std")]
+impl std::error::Error for InvalidHTTPStatusCode {}
 
 impl From<HTTPStatus> for Status {
     fn from(val: HTTPStatus) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,12 @@
 //! # now you can use dynamic modules with the NGINX
 //! ```
 
+// support both std and no_std
+#![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
+#[cfg(all(not(feature = "std"), feature = "alloc"))]
+extern crate alloc;
+
 /// The core module.
 ///
 /// This module provides fundamental utilities needed to interface with many NGINX primitives.
@@ -54,6 +59,9 @@ pub mod http;
 /// The log module.
 ///
 /// This module provides an interface into the NGINX logger framework.
+///
+/// This module is temporally available only with `std` feature.
+#[cfg(feature = "std")]
 pub mod log;
 
 /// Define modules exported by this library.
@@ -67,20 +75,20 @@ macro_rules! ngx_modules {
         #[allow(non_upper_case_globals)]
         pub static mut ngx_modules: [*const $crate::ffi::ngx_module_t; $crate::count!($( $mod, )+) + 1] = [
             $( unsafe { &$mod } as *const $crate::ffi::ngx_module_t, )+
-            ::std::ptr::null()
+            ::core::ptr::null()
         ];
 
         #[no_mangle]
         #[allow(non_upper_case_globals)]
-        pub static mut ngx_module_names: [*const ::std::ffi::c_char; $crate::count!($( $mod, )+) + 1] = [
-            $( concat!(stringify!($mod), "\0").as_ptr() as *const ::std::ffi::c_char, )+
-            ::std::ptr::null()
+        pub static mut ngx_module_names: [*const ::core::ffi::c_char; $crate::count!($( $mod, )+) + 1] = [
+            $( concat!(stringify!($mod), "\0").as_ptr() as *const ::core::ffi::c_char, )+
+            ::core::ptr::null()
         ];
 
         #[no_mangle]
         #[allow(non_upper_case_globals)]
-        pub static mut ngx_module_order: [*const ::std::ffi::c_char; 1] = [
-            ::std::ptr::null()
+        pub static mut ngx_module_order: [*const ::core::ffi::c_char; 1] = [
+            ::core::ptr::null()
         ];
     };
 }


### PR DESCRIPTION
### Proposed changes
add features `std`, `alloc` to prepare for `no_std` build support.
- `alloc` feature means memory allocation used. Implementation differs depending on `std` feature:
  - with `std`: use `std` crate components. (e.g. `std::string::String`)
  - without `std`: use `alloc` crate components. (e.g. `alloc::string::String`)
- `std` feature means `std` crate components used. Currently the only difference between `std` and `alloc` is impl of `std::error::Error` (`core::error::Error` is not in Rust 1.79.0), which is not used.

`alloc` is the transitional feature: while it enables `no_std` build, it allows memory allocation using `std::alloc::System` internally. We can gradually replace `alloc` crate components by nginx-based ones.

For these features, many `std` imports are replaced by `core` ones.

Related issue (enhancement): https://github.com/nginxinc/ngx-rust/issues/109

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have added tests (when possible) that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto master
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
