### PR TITLE
Logging improvements, second try

### DIFF
--- a/examples/upstream.rs
+++ b/examples/upstream.rs
@@ -24,7 +24,6 @@ use ngx::http::{
     ngx_http_conf_get_module_srv_conf, ngx_http_conf_upstream_srv_conf_immutable,
     ngx_http_conf_upstream_srv_conf_mutable, HTTPModule, Merge, MergeConfigError, Request,
 };
-use ngx::log::DebugMask;
 use ngx::{http_upstream_init_peer_pt, ngx_log_debug_http, ngx_log_debug_mask, ngx_null_command, ngx_string};
 
 #[derive(Clone, Copy, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,9 +59,6 @@ pub mod http;
 /// The log module.
 ///
 /// This module provides an interface into the NGINX logger framework.
-///
-/// This module is temporally available only with `std` feature.
-#[cfg(feature = "std")]
 pub mod log;
 
 /// Define modules exported by this library.

--- a/src/log.rs
+++ b/src/log.rs
@@ -18,10 +18,10 @@ macro_rules! ngx_log_debug {
         let log = $log;
         if $crate::log::check_mask($mask, unsafe { (*log).log_level }) {
             let level = $crate::ffi::NGX_LOG_DEBUG as $crate::ffi::ngx_uint_t;
-            let fmt = ::std::ffi::CString::new("%s").unwrap();
-            let c_message = ::std::ffi::CString::new(format!($($arg)+)).unwrap();
+            let message = format!($($arg)+);
+            let message = message.as_bytes();
             unsafe {
-                $crate::ffi::ngx_log_error_core(level, log, 0, fmt.as_ptr(), c_message.as_ptr());
+                $crate::ffi::ngx_log_error_core(level, log, 0, c"%*s".as_ptr(), message.len(), message.as_ptr());
             }
         }
     };


### PR DESCRIPTION
Less ambitious attempt to rewrite the logger.

Two goals for this PR:
 - add `ngx_log_error!`/`ngx_log_conf_error` macros
 - avoid allocations in the logger