### PR TITLE
fix: remove unnecessary `#[no_mangle]` attributes

### DIFF
--- a/examples/async.rs
+++ b/examples/async.rs
@@ -54,7 +54,7 @@ impl Default for ModuleConfig {
     }
 }
 
-static mut ngx_http_async_commands: [ngx_command_t; 2] = [
+static mut NGX_HTTP_ASYNC_COMMANDS: [ngx_command_t; 2] = [
     ngx_command_t {
         name: ngx_string!("async"),
         type_: (NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1) as ngx_uint_t,
@@ -66,7 +66,7 @@ static mut ngx_http_async_commands: [ngx_command_t; 2] = [
     ngx_null_command!(),
 ];
 
-static ngx_http_async_module_ctx: ngx_http_module_t = ngx_http_module_t {
+static NGX_HTTP_ASYNC_MODULE_CTX: ngx_http_module_t = ngx_http_module_t {
     preconfiguration: Some(Module::preconfiguration),
     postconfiguration: Some(Module::postconfiguration),
     create_main_conf: Some(Module::create_main_conf),
@@ -83,6 +83,7 @@ static ngx_http_async_module_ctx: ngx_http_module_t = ngx_http_module_t {
 ngx::ngx_modules!(ngx_http_async_module);
 
 #[used]
+#[allow(non_upper_case_globals)]
 #[cfg_attr(not(feature = "export-modules"), no_mangle)]
 pub static mut ngx_http_async_module: ngx_module_t = ngx_module_t {
     ctx_index: ngx_uint_t::MAX,
@@ -93,8 +94,8 @@ pub static mut ngx_http_async_module: ngx_module_t = ngx_module_t {
     version: nginx_version as ngx_uint_t,
     signature: NGX_RS_MODULE_SIGNATURE.as_ptr() as *const c_char,
 
-    ctx: &ngx_http_async_module_ctx as *const _ as *mut _,
-    commands: unsafe { &ngx_http_async_commands[0] as *const _ as *mut _ },
+    ctx: &NGX_HTTP_ASYNC_MODULE_CTX as *const _ as *mut _,
+    commands: unsafe { &NGX_HTTP_ASYNC_COMMANDS[0] as *const _ as *mut _ },
     type_: NGX_HTTP_MODULE as ngx_uint_t,
 
     init_master: None,

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -54,7 +54,6 @@ impl Default for ModuleConfig {
     }
 }
 
-#[no_mangle]
 static mut ngx_http_async_commands: [ngx_command_t; 2] = [
     ngx_command_t {
         name: ngx_string!("async"),
@@ -67,7 +66,6 @@ static mut ngx_http_async_commands: [ngx_command_t; 2] = [
     ngx_null_command!(),
 ];
 
-#[no_mangle]
 static ngx_http_async_module_ctx: ngx_http_module_t = ngx_http_module_t {
     preconfiguration: Some(Module::preconfiguration),
     postconfiguration: Some(Module::postconfiguration),
@@ -84,8 +82,8 @@ static ngx_http_async_module_ctx: ngx_http_module_t = ngx_http_module_t {
 #[cfg(feature = "export-modules")]
 ngx::ngx_modules!(ngx_http_async_module);
 
-#[no_mangle]
 #[used]
+#[cfg_attr(not(feature = "export-modules"), no_mangle)]
 pub static mut ngx_http_async_module: ngx_module_t = ngx_module_t {
     ctx_index: ngx_uint_t::MAX,
     index: ngx_uint_t::MAX,
@@ -235,7 +233,6 @@ http_request_handler!(async_access_handler, |request: &mut http::Request| {
     core::Status::NGX_DONE
 });
 
-#[no_mangle]
 extern "C" fn ngx_http_async_commands_set_enable(
     cf: *mut ngx_conf_t,
     _cmd: *mut ngx_command_t,

--- a/examples/awssig.rs
+++ b/examples/awssig.rs
@@ -42,7 +42,6 @@ struct ModuleConfig {
     s3_endpoint: String,
 }
 
-#[no_mangle]
 static mut ngx_http_awssigv4_commands: [ngx_command_t; 6] = [
     ngx_command_t {
         name: ngx_string!("awssigv4"),
@@ -87,7 +86,6 @@ static mut ngx_http_awssigv4_commands: [ngx_command_t; 6] = [
     ngx_null_command!(),
 ];
 
-#[no_mangle]
 static ngx_http_awssigv4_module_ctx: ngx_http_module_t = ngx_http_module_t {
     preconfiguration: Some(Module::preconfiguration),
     postconfiguration: Some(Module::postconfiguration),
@@ -104,8 +102,8 @@ static ngx_http_awssigv4_module_ctx: ngx_http_module_t = ngx_http_module_t {
 #[cfg(feature = "export-modules")]
 ngx::ngx_modules!(ngx_http_awssigv4_module);
 
-#[no_mangle]
 #[used]
+#[cfg_attr(not(feature = "export-modules"), no_mangle)]
 pub static mut ngx_http_awssigv4_module: ngx_module_t = ngx_module_t {
     ctx_index: ngx_uint_t::MAX,
     index: ngx_uint_t::MAX,
@@ -187,7 +185,6 @@ impl Merge for ModuleConfig {
     }
 }
 
-#[no_mangle]
 extern "C" fn ngx_http_awssigv4_commands_set_enable(
     cf: *mut ngx_conf_t,
     _cmd: *mut ngx_command_t,
@@ -211,7 +208,6 @@ extern "C" fn ngx_http_awssigv4_commands_set_enable(
     std::ptr::null_mut()
 }
 
-#[no_mangle]
 extern "C" fn ngx_http_awssigv4_commands_set_access_key(
     cf: *mut ngx_conf_t,
     _cmd: *mut ngx_command_t,
@@ -226,7 +222,6 @@ extern "C" fn ngx_http_awssigv4_commands_set_access_key(
     std::ptr::null_mut()
 }
 
-#[no_mangle]
 extern "C" fn ngx_http_awssigv4_commands_set_secret_key(
     cf: *mut ngx_conf_t,
     _cmd: *mut ngx_command_t,
@@ -241,7 +236,6 @@ extern "C" fn ngx_http_awssigv4_commands_set_secret_key(
     std::ptr::null_mut()
 }
 
-#[no_mangle]
 extern "C" fn ngx_http_awssigv4_commands_set_s3_bucket(
     cf: *mut ngx_conf_t,
     _cmd: *mut ngx_command_t,
@@ -259,7 +253,6 @@ extern "C" fn ngx_http_awssigv4_commands_set_s3_bucket(
     std::ptr::null_mut()
 }
 
-#[no_mangle]
 extern "C" fn ngx_http_awssigv4_commands_set_s3_endpoint(
     cf: *mut ngx_conf_t,
     _cmd: *mut ngx_command_t,

--- a/examples/awssig.rs
+++ b/examples/awssig.rs
@@ -42,7 +42,7 @@ struct ModuleConfig {
     s3_endpoint: String,
 }
 
-static mut ngx_http_awssigv4_commands: [ngx_command_t; 6] = [
+static mut NGX_HTTP_AWSSIGV4_COMMANDS: [ngx_command_t; 6] = [
     ngx_command_t {
         name: ngx_string!("awssigv4"),
         type_: (NGX_HTTP_LOC_CONF | NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1) as ngx_uint_t,
@@ -86,7 +86,7 @@ static mut ngx_http_awssigv4_commands: [ngx_command_t; 6] = [
     ngx_null_command!(),
 ];
 
-static ngx_http_awssigv4_module_ctx: ngx_http_module_t = ngx_http_module_t {
+static NGX_HTTP_AWSSIGV4_MODULE_CTX: ngx_http_module_t = ngx_http_module_t {
     preconfiguration: Some(Module::preconfiguration),
     postconfiguration: Some(Module::postconfiguration),
     create_main_conf: Some(Module::create_main_conf),
@@ -103,6 +103,7 @@ static ngx_http_awssigv4_module_ctx: ngx_http_module_t = ngx_http_module_t {
 ngx::ngx_modules!(ngx_http_awssigv4_module);
 
 #[used]
+#[allow(non_upper_case_globals)]
 #[cfg_attr(not(feature = "export-modules"), no_mangle)]
 pub static mut ngx_http_awssigv4_module: ngx_module_t = ngx_module_t {
     ctx_index: ngx_uint_t::MAX,
@@ -113,8 +114,8 @@ pub static mut ngx_http_awssigv4_module: ngx_module_t = ngx_module_t {
     version: nginx_version as ngx_uint_t,
     signature: NGX_RS_MODULE_SIGNATURE.as_ptr() as *const c_char,
 
-    ctx: &ngx_http_awssigv4_module_ctx as *const _ as *mut _,
-    commands: unsafe { &ngx_http_awssigv4_commands[0] as *const _ as *mut _ },
+    ctx: &NGX_HTTP_AWSSIGV4_MODULE_CTX as *const _ as *mut _,
+    commands: unsafe { &NGX_HTTP_AWSSIGV4_COMMANDS[0] as *const _ as *mut _ },
     type_: NGX_HTTP_MODULE as ngx_uint_t,
 
     init_master: None,

--- a/examples/curl.rs
+++ b/examples/curl.rs
@@ -36,7 +36,6 @@ struct ModuleConfig {
     enable: bool,
 }
 
-#[no_mangle]
 static mut ngx_http_curl_commands: [ngx_command_t; 2] = [
     ngx_command_t {
         name: ngx_string!("curl"),
@@ -49,7 +48,6 @@ static mut ngx_http_curl_commands: [ngx_command_t; 2] = [
     ngx_null_command!(),
 ];
 
-#[no_mangle]
 static ngx_http_curl_module_ctx: ngx_http_module_t = ngx_http_module_t {
     preconfiguration: Some(Module::preconfiguration),
     postconfiguration: Some(Module::postconfiguration),
@@ -66,8 +64,8 @@ static ngx_http_curl_module_ctx: ngx_http_module_t = ngx_http_module_t {
 #[cfg(feature = "export-modules")]
 ngx::ngx_modules!(ngx_http_curl_module);
 
-#[no_mangle]
 #[used]
+#[cfg_attr(not(feature = "export-modules"), no_mangle)]
 pub static mut ngx_http_curl_module: ngx_module_t = ngx_module_t {
     ctx_index: ngx_uint_t::MAX,
     index: ngx_uint_t::MAX,
@@ -129,7 +127,6 @@ http_request_handler!(curl_access_handler, |request: &mut http::Request| {
     }
 });
 
-#[no_mangle]
 extern "C" fn ngx_http_curl_commands_set_enable(
     cf: *mut ngx_conf_t,
     _cmd: *mut ngx_command_t,

--- a/examples/curl.rs
+++ b/examples/curl.rs
@@ -36,7 +36,7 @@ struct ModuleConfig {
     enable: bool,
 }
 
-static mut ngx_http_curl_commands: [ngx_command_t; 2] = [
+static mut NGX_HTTP_CURL_COMMANDS: [ngx_command_t; 2] = [
     ngx_command_t {
         name: ngx_string!("curl"),
         type_: (NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1) as ngx_uint_t,
@@ -48,7 +48,7 @@ static mut ngx_http_curl_commands: [ngx_command_t; 2] = [
     ngx_null_command!(),
 ];
 
-static ngx_http_curl_module_ctx: ngx_http_module_t = ngx_http_module_t {
+static NGX_HTTP_CURL_MODULE_CTX: ngx_http_module_t = ngx_http_module_t {
     preconfiguration: Some(Module::preconfiguration),
     postconfiguration: Some(Module::postconfiguration),
     create_main_conf: Some(Module::create_main_conf),
@@ -65,6 +65,7 @@ static ngx_http_curl_module_ctx: ngx_http_module_t = ngx_http_module_t {
 ngx::ngx_modules!(ngx_http_curl_module);
 
 #[used]
+#[allow(non_upper_case_globals)]
 #[cfg_attr(not(feature = "export-modules"), no_mangle)]
 pub static mut ngx_http_curl_module: ngx_module_t = ngx_module_t {
     ctx_index: ngx_uint_t::MAX,
@@ -75,8 +76,8 @@ pub static mut ngx_http_curl_module: ngx_module_t = ngx_module_t {
     version: nginx_version as ngx_uint_t,
     signature: NGX_RS_MODULE_SIGNATURE.as_ptr() as *const c_char,
 
-    ctx: &ngx_http_curl_module_ctx as *const _ as *mut _,
-    commands: unsafe { &ngx_http_curl_commands[0] as *const _ as *mut _ },
+    ctx: &NGX_HTTP_CURL_MODULE_CTX as *const _ as *mut _,
+    commands: unsafe { &NGX_HTTP_CURL_COMMANDS[0] as *const _ as *mut _ },
     type_: NGX_HTTP_MODULE as ngx_uint_t,
 
     init_master: None,

--- a/examples/httporigdst.rs
+++ b/examples/httporigdst.rs
@@ -76,7 +76,7 @@ impl NgxHttpOrigDstCtx {
     }
 }
 
-static ngx_http_orig_dst_module_ctx: ngx_http_module_t = ngx_http_module_t {
+static NGX_HTTP_ORIG_DST_MODULE_CTX: ngx_http_module_t = ngx_http_module_t {
     preconfiguration: Some(Module::preconfiguration),
     postconfiguration: Some(Module::postconfiguration),
     create_main_conf: Some(Module::create_main_conf),
@@ -93,6 +93,7 @@ static ngx_http_orig_dst_module_ctx: ngx_http_module_t = ngx_http_module_t {
 ngx::ngx_modules!(ngx_http_orig_dst_module);
 
 #[used]
+#[allow(non_upper_case_globals)]
 #[cfg_attr(not(feature = "export-modules"), no_mangle)]
 pub static mut ngx_http_orig_dst_module: ngx_module_t = ngx_module_t {
     ctx_index: ngx_uint_t::MAX,
@@ -102,7 +103,7 @@ pub static mut ngx_http_orig_dst_module: ngx_module_t = ngx_module_t {
     spare1: 0,
     version: nginx_version as ngx_uint_t,
     signature: NGX_RS_MODULE_SIGNATURE.as_ptr() as *const c_char,
-    ctx: &ngx_http_orig_dst_module_ctx as *const _ as *mut _,
+    ctx: &NGX_HTTP_ORIG_DST_MODULE_CTX as *const _ as *mut _,
     commands: std::ptr::null_mut(),
     type_: NGX_HTTP_MODULE as ngx_uint_t,
 
@@ -124,7 +125,7 @@ pub static mut ngx_http_orig_dst_module: ngx_module_t = ngx_module_t {
     spare_hook7: 0,
 };
 
-static mut ngx_http_orig_dst_vars: [ngx_http_variable_t; 3] = [
+static mut NGX_HTTP_ORIG_DST_VARS: [ngx_http_variable_t; 3] = [
     // ngx_str_t name
     // ngx_http_set_variable_pt set_handler
     // ngx_http_get_variable_pt get_handler
@@ -297,7 +298,7 @@ impl HTTPModule for Module {
 
     // static ngx_int_t ngx_http_orig_dst_add_variables(ngx_conf_t *cf)
     unsafe extern "C" fn preconfiguration(cf: *mut ngx_conf_t) -> ngx_int_t {
-        for mut v in ngx_http_orig_dst_vars {
+        for mut v in NGX_HTTP_ORIG_DST_VARS {
             if v.name.len == 0 {
                 break;
             }

--- a/examples/httporigdst.rs
+++ b/examples/httporigdst.rs
@@ -76,7 +76,6 @@ impl NgxHttpOrigDstCtx {
     }
 }
 
-#[no_mangle]
 static ngx_http_orig_dst_module_ctx: ngx_http_module_t = ngx_http_module_t {
     preconfiguration: Some(Module::preconfiguration),
     postconfiguration: Some(Module::postconfiguration),
@@ -93,8 +92,8 @@ static ngx_http_orig_dst_module_ctx: ngx_http_module_t = ngx_http_module_t {
 #[cfg(feature = "export-modules")]
 ngx::ngx_modules!(ngx_http_orig_dst_module);
 
-#[no_mangle]
 #[used]
+#[cfg_attr(not(feature = "export-modules"), no_mangle)]
 pub static mut ngx_http_orig_dst_module: ngx_module_t = ngx_module_t {
     ctx_index: ngx_uint_t::MAX,
     index: ngx_uint_t::MAX,
@@ -125,7 +124,6 @@ pub static mut ngx_http_orig_dst_module: ngx_module_t = ngx_module_t {
     spare_hook7: 0,
 };
 
-#[no_mangle]
 static mut ngx_http_orig_dst_vars: [ngx_http_variable_t; 3] = [
     // ngx_str_t name
     // ngx_http_set_variable_pt set_handler

--- a/examples/upstream.rs
+++ b/examples/upstream.rs
@@ -76,7 +76,7 @@ impl Default for UpstreamPeerData {
     }
 }
 
-static ngx_http_upstream_custom_ctx: ngx_http_module_t = ngx_http_module_t {
+static NGX_HTTP_UPSTREAM_CUSTOM_CTX: ngx_http_module_t = ngx_http_module_t {
     preconfiguration: Some(Module::preconfiguration),
     postconfiguration: Some(Module::postconfiguration),
     create_main_conf: Some(Module::create_main_conf),
@@ -87,7 +87,7 @@ static ngx_http_upstream_custom_ctx: ngx_http_module_t = ngx_http_module_t {
     merge_loc_conf: Some(Module::merge_loc_conf),
 };
 
-static mut ngx_http_upstream_custom_commands: [ngx_command_t; 2] = [
+static mut NGX_HTTP_UPSTREAM_CUSTOM_COMMANDS: [ngx_command_t; 2] = [
     ngx_command_t {
         name: ngx_string!("custom"),
         type_: (NGX_HTTP_UPS_CONF | NGX_CONF_NOARGS | NGX_CONF_TAKE1) as ngx_uint_t,
@@ -105,6 +105,7 @@ static mut ngx_http_upstream_custom_commands: [ngx_command_t; 2] = [
 ngx::ngx_modules!(ngx_http_upstream_custom_module);
 
 #[used]
+#[allow(non_upper_case_globals)]
 #[cfg_attr(not(feature = "export-modules"), no_mangle)]
 pub static mut ngx_http_upstream_custom_module: ngx_module_t = ngx_module_t {
     ctx_index: ngx_uint_t::MAX,
@@ -115,8 +116,8 @@ pub static mut ngx_http_upstream_custom_module: ngx_module_t = ngx_module_t {
     version: nginx_version as ngx_uint_t,
     signature: NGX_RS_MODULE_SIGNATURE.as_ptr() as *const c_char,
 
-    ctx: &ngx_http_upstream_custom_ctx as *const _ as *mut _,
-    commands: unsafe { &ngx_http_upstream_custom_commands[0] as *const _ as *mut _ },
+    ctx: &NGX_HTTP_UPSTREAM_CUSTOM_CTX as *const _ as *mut _,
+    commands: unsafe { &NGX_HTTP_UPSTREAM_CUSTOM_COMMANDS[0] as *const _ as *mut _ },
     type_: NGX_HTTP_MODULE as ngx_uint_t,
 
     init_master: None,

--- a/examples/upstream.rs
+++ b/examples/upstream.rs
@@ -76,7 +76,6 @@ impl Default for UpstreamPeerData {
     }
 }
 
-#[no_mangle]
 static ngx_http_upstream_custom_ctx: ngx_http_module_t = ngx_http_module_t {
     preconfiguration: Some(Module::preconfiguration),
     postconfiguration: Some(Module::postconfiguration),
@@ -88,7 +87,6 @@ static ngx_http_upstream_custom_ctx: ngx_http_module_t = ngx_http_module_t {
     merge_loc_conf: Some(Module::merge_loc_conf),
 };
 
-#[no_mangle]
 static mut ngx_http_upstream_custom_commands: [ngx_command_t; 2] = [
     ngx_command_t {
         name: ngx_string!("custom"),
@@ -106,8 +104,8 @@ static mut ngx_http_upstream_custom_commands: [ngx_command_t; 2] = [
 #[cfg(feature = "export-modules")]
 ngx::ngx_modules!(ngx_http_upstream_custom_module);
 
-#[no_mangle]
 #[used]
+#[cfg_attr(not(feature = "export-modules"), no_mangle)]
 pub static mut ngx_http_upstream_custom_module: ngx_module_t = ngx_module_t {
     ctx_index: ngx_uint_t::MAX,
     index: ngx_uint_t::MAX,
@@ -191,7 +189,6 @@ http_upstream_init_peer_pt!(
 // ngx_http_usptream_get_custom_peer
 // For demonstration purposes, use the original get callback, but log this callback proxies through
 // to the original.
-#[no_mangle]
 unsafe extern "C" fn ngx_http_upstream_get_custom_peer(pc: *mut ngx_peer_connection_t, data: *mut c_void) -> ngx_int_t {
     let hcpd: *mut UpstreamPeerData = unsafe { mem::transmute(data) };
 
@@ -217,7 +214,6 @@ unsafe extern "C" fn ngx_http_upstream_get_custom_peer(pc: *mut ngx_peer_connect
 // ngx_http_upstream_free_custom_peer
 // For demonstration purposes, use the original free callback, but log this callback proxies
 // through to the original.
-#[no_mangle]
 unsafe extern "C" fn ngx_http_upstream_free_custom_peer(
     pc: *mut ngx_peer_connection_t,
     data: *mut c_void,
@@ -237,7 +233,6 @@ unsafe extern "C" fn ngx_http_upstream_free_custom_peer(
 // ngx_http_upstream_init_custom
 // The module's custom `peer.init_upstream` callback.
 // The original callback is saved in our SrvConfig data and reset to this module's `peer.init`.
-#[no_mangle]
 unsafe extern "C" fn ngx_http_upstream_init_custom(
     cf: *mut ngx_conf_t,
     us: *mut ngx_http_upstream_srv_conf_t,
@@ -282,7 +277,6 @@ unsafe extern "C" fn ngx_http_upstream_init_custom(
 // ngx_http_upstream_commands_set_custom
 // Entry point for the module, if this command is set our custom upstreams take effect.
 // The original upstream initializer function is saved and replaced with this module's initializer.
-#[no_mangle]
 unsafe extern "C" fn ngx_http_upstream_commands_set_custom(
     cf: *mut ngx_conf_t,
     cmd: *mut ngx_command_t,

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -14,7 +14,6 @@ use crate::ngx_null_string;
 #[macro_export]
 macro_rules! http_request_handler {
     ( $name: ident, $handler: expr ) => {
-        #[no_mangle]
         extern "C" fn $name(r: *mut $crate::ffi::ngx_http_request_t) -> $crate::ffi::ngx_int_t {
             let status: $crate::core::Status =
                 $handler(unsafe { &mut $crate::http::Request::from_ngx_http_request(r) });
@@ -29,7 +28,6 @@ macro_rules! http_request_handler {
 #[macro_export]
 macro_rules! http_subrequest_handler {
     ( $name: ident, $handler: expr ) => {
-        #[no_mangle]
         unsafe extern "C" fn $name(
             r: *mut $crate::ffi::ngx_http_request_t,
             data: *mut ::std::ffi::c_void,
@@ -48,7 +46,6 @@ macro_rules! http_subrequest_handler {
 #[macro_export]
 macro_rules! http_variable_set {
     ( $name: ident, $handler: expr ) => {
-        #[no_mangle]
         unsafe extern "C" fn $name(
             r: *mut $crate::ffi::ngx_http_request_t,
             v: *mut $crate::ffi::ngx_variable_value_t,
@@ -72,7 +69,6 @@ macro_rules! http_variable_set {
 #[macro_export]
 macro_rules! http_variable_get {
     ( $name: ident, $handler: expr ) => {
-        #[no_mangle]
         unsafe extern "C" fn $name(
             r: *mut $crate::ffi::ngx_http_request_t,
             v: *mut $crate::ffi::ngx_variable_value_t,

--- a/src/http/upstream.rs
+++ b/src/http/upstream.rs
@@ -12,7 +12,6 @@
 #[macro_export]
 macro_rules! http_upstream_init_peer_pt {
     ( $name: ident, $handler: expr ) => {
-        #[no_mangle]
         extern "C" fn $name(
             r: *mut $crate::ffi::ngx_http_request_t,
             us: *mut $crate::ffi::ngx_http_upstream_srv_conf_t,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,18 +64,21 @@ pub mod log;
 macro_rules! ngx_modules {
     ($( $mod:ident ),+) => {
         #[no_mangle]
+        #[allow(non_upper_case_globals)]
         pub static mut ngx_modules: [*const $crate::ffi::ngx_module_t; $crate::count!($( $mod, )+) + 1] = [
             $( unsafe { &$mod } as *const $crate::ffi::ngx_module_t, )+
             ::std::ptr::null()
         ];
 
         #[no_mangle]
+        #[allow(non_upper_case_globals)]
         pub static mut ngx_module_names: [*const ::std::ffi::c_char; $crate::count!($( $mod, )+) + 1] = [
             $( concat!(stringify!($mod), "\0").as_ptr() as *const ::std::ffi::c_char, )+
             ::std::ptr::null()
         ];
 
         #[no_mangle]
+        #[allow(non_upper_case_globals)]
         pub static mut ngx_module_order: [*const ::std::ffi::c_char; 1] = [
             ::std::ptr::null()
         ];


### PR DESCRIPTION
`#[no_mangle]` is only necessary for the symbols that are exported by **name**. That is, exported module lists for the `cdylib` build and individual `ngx_module_t` globals for the `staticlib`.

`extern "C"` ABI specification is sufficient for all the remaining symbols that we pass to the NGINX C code by address.

Fixes: https://github.com/nginxinc/ngx-rust/issues/102