### PR TITLE
ngx::core::Pool's methods are &self, not &mut self

### DIFF
--- a/examples/httporigdst.rs
+++ b/examples/httporigdst.rs
@@ -19,7 +19,7 @@ struct NgxHttpOrigDstCtx {
 }
 
 impl NgxHttpOrigDstCtx {
-    pub fn save(&mut self, addr: &str, port: in_port_t, pool: &mut core::Pool) -> core::Status {
+    pub fn save(&mut self, addr: &str, port: in_port_t, pool: &core::Pool) -> core::Status {
         let addr_data = pool.alloc_unaligned(addr.len());
         if addr_data.is_null() {
             return core::Status::NGX_ERROR;
@@ -226,7 +226,7 @@ http_variable_get!(
                     ip,
                     port,
                 );
-                (*new_ctx).save(&ip, port, &mut request.pool());
+                (*new_ctx).save(&ip, port, &request.pool());
                 (*new_ctx).bind_addr(v);
                 request
                     .set_module_ctx(new_ctx as *mut c_void, &*addr_of!(ngx_http_orig_dst_module));
@@ -273,7 +273,7 @@ http_variable_get!(
                     ip,
                     port,
                 );
-                (*new_ctx).save(&ip, port, &mut request.pool());
+                (*new_ctx).save(&ip, port, &request.pool());
                 (*new_ctx).bind_port(v);
                 request
                     .set_module_ctx(new_ctx as *mut c_void, &*addr_of!(ngx_http_orig_dst_module));

--- a/examples/shared_dict.rs
+++ b/examples/shared_dict.rs
@@ -198,7 +198,7 @@ extern "C" fn ngx_http_shared_dict_add_variable(
 ) -> *mut c_char {
     // SAFETY: configuration handlers always receive a valid `cf` pointer.
     let cf = unsafe { cf.as_mut().unwrap() };
-    let mut pool = unsafe { Pool::from_ngx_pool(cf.pool) };
+    let pool = unsafe { Pool::from_ngx_pool(cf.pool) };
 
     let key = pool.calloc_type::<ngx_http_complex_value_t>();
     if key.is_null() {

--- a/examples/upstream.rs
+++ b/examples/upstream.rs
@@ -311,7 +311,7 @@ impl HttpModule for Module {
     }
 
     unsafe extern "C" fn create_srv_conf(cf: *mut ngx_conf_t) -> *mut c_void {
-        let mut pool = Pool::from_ngx_pool((*cf).pool);
+        let pool = Pool::from_ngx_pool((*cf).pool);
         let conf = pool.alloc_type::<SrvConfig>();
         if conf.is_null() {
             ngx_conf_log_error!(

--- a/src/core/pool.rs
+++ b/src/core/pool.rs
@@ -101,8 +101,8 @@ impl Pool {
     ///
     /// Returns `Some(TemporaryBuffer)` if the buffer is successfully created, or `None` if
     /// allocation fails.
-    pub fn create_buffer(&mut self, size: usize) -> Option<TemporaryBuffer> {
-        let buf = unsafe { ngx_create_temp_buf(self.as_mut(), size) };
+    pub fn create_buffer(&self, size: usize) -> Option<TemporaryBuffer> {
+        let buf = unsafe { ngx_create_temp_buf(self.0.as_ptr(), size) };
         if buf.is_null() {
             return None;
         }
@@ -114,7 +114,7 @@ impl Pool {
     ///
     /// Returns `Some(TemporaryBuffer)` if the buffer is successfully created, or `None` if
     /// allocation fails.
-    pub fn create_buffer_from_str(&mut self, str: &str) -> Option<TemporaryBuffer> {
+    pub fn create_buffer_from_str(&self, str: &str) -> Option<TemporaryBuffer> {
         let mut buffer = self.create_buffer(str.len())?;
         unsafe {
             let buf = buffer.as_ngx_buf_mut();
@@ -128,7 +128,7 @@ impl Pool {
     ///
     /// Returns `Some(MemoryBuffer)` if the buffer is successfully created, or `None` if allocation
     /// fails.
-    pub fn create_buffer_from_static_str(&mut self, str: &'static str) -> Option<MemoryBuffer> {
+    pub fn create_buffer_from_static_str(&self, str: &'static str) -> Option<MemoryBuffer> {
         let buf = self.calloc_type::<ngx_buf_t>();
         if buf.is_null() {
             return None;
@@ -156,7 +156,7 @@ impl Pool {
     ///
     /// # Safety
     /// This function is marked as unsafe because it involves raw pointer manipulation.
-    unsafe fn add_cleanup_for_value<T>(&mut self, value: *mut T) -> Result<(), ()> {
+    unsafe fn add_cleanup_for_value<T>(&self, value: *mut T) -> Result<(), ()> {
         let cln = ngx_pool_cleanup_add(self.0.as_ptr(), 0);
         if cln.is_null() {
             return Err(());
@@ -171,7 +171,7 @@ impl Pool {
     /// The resulting pointer is aligned to a platform word size.
     ///
     /// Returns a raw pointer to the allocated memory.
-    pub fn alloc(&mut self, size: usize) -> *mut c_void {
+    pub fn alloc(&self, size: usize) -> *mut c_void {
         unsafe { ngx_palloc(self.0.as_ptr(), size) }
     }
 
@@ -179,7 +179,7 @@ impl Pool {
     /// The resulting pointer is aligned to a platform word size.
     ///
     /// Returns a typed pointer to the allocated memory.
-    pub fn alloc_type<T: Copy>(&mut self) -> *mut T {
+    pub fn alloc_type<T: Copy>(&self) -> *mut T {
         self.alloc(mem::size_of::<T>()) as *mut T
     }
 
@@ -187,7 +187,7 @@ impl Pool {
     /// The resulting pointer is aligned to a platform word size.
     ///
     /// Returns a raw pointer to the allocated memory.
-    pub fn calloc(&mut self, size: usize) -> *mut c_void {
+    pub fn calloc(&self, size: usize) -> *mut c_void {
         unsafe { ngx_pcalloc(self.0.as_ptr(), size) }
     }
 
@@ -195,21 +195,21 @@ impl Pool {
     /// The resulting pointer is aligned to a platform word size.
     ///
     /// Returns a typed pointer to the allocated memory.
-    pub fn calloc_type<T: Copy>(&mut self) -> *mut T {
+    pub fn calloc_type<T: Copy>(&self) -> *mut T {
         self.calloc(mem::size_of::<T>()) as *mut T
     }
 
     /// Allocates unaligned memory from the pool of the specified size.
     ///
     /// Returns a raw pointer to the allocated memory.
-    pub fn alloc_unaligned(&mut self, size: usize) -> *mut c_void {
+    pub fn alloc_unaligned(&self, size: usize) -> *mut c_void {
         unsafe { ngx_pnalloc(self.0.as_ptr(), size) }
     }
 
     /// Allocates unaligned memory for a type from the pool.
     ///
     /// Returns a typed pointer to the allocated memory.
-    pub fn alloc_type_unaligned<T: Copy>(&mut self) -> *mut T {
+    pub fn alloc_type_unaligned<T: Copy>(&self) -> *mut T {
         self.alloc_unaligned(mem::size_of::<T>()) as *mut T
     }
 
@@ -218,7 +218,7 @@ impl Pool {
     ///
     /// Returns a typed pointer to the allocated memory if successful, or a null pointer if
     /// allocation or cleanup handler addition fails.
-    pub fn allocate<T>(&mut self, value: T) -> *mut T {
+    pub fn allocate<T>(&self, value: T) -> *mut T {
         unsafe {
             let p = self.alloc(mem::size_of::<T>()) as *mut T;
             ptr::write(p, value);

--- a/src/http/module.rs
+++ b/src/http/module.rs
@@ -77,7 +77,7 @@ pub trait HttpModule {
         Self: super::HttpModuleMainConf,
         Self::MainConf: Default,
     {
-        let mut pool = Pool::from_ngx_pool((*cf).pool);
+        let pool = Pool::from_ngx_pool((*cf).pool);
         pool.allocate::<Self::MainConf>(Default::default()) as *mut c_void
     }
 
@@ -102,7 +102,7 @@ pub trait HttpModule {
         Self: super::HttpModuleServerConf,
         Self::ServerConf: Default,
     {
-        let mut pool = Pool::from_ngx_pool((*cf).pool);
+        let pool = Pool::from_ngx_pool((*cf).pool);
         pool.allocate::<Self::ServerConf>(Default::default()) as *mut c_void
     }
 
@@ -136,7 +136,7 @@ pub trait HttpModule {
         Self: super::HttpModuleLocationConf,
         Self::LocationConf: Default,
     {
-        let mut pool = Pool::from_ngx_pool((*cf).pool);
+        let pool = Pool::from_ngx_pool((*cf).pool);
         pool.allocate::<Self::LocationConf>(Default::default()) as *mut c_void
     }
 


### PR DESCRIPTION
The interior pointer to ngx_pool_t provides the mutability we need here - there is no requirement for the use of the ngx_pool_t to be unique, so restricting the methods to &mut self just adds additional difficulty without any safety benefit.

Closes #192 

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [n/a] I have added tests (when possible) that prove my fix is effective or that my feature works
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
