### PR TITLE
refactor: use foreign-type for request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,6 +331,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,6 +623,7 @@ version = "0.5.0"
 dependencies = [
  "allocator-api2",
  "async-task",
+ "foreign-types",
  "lock_api",
  "nginx-sys",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ targets = []
 [dependencies]
 allocator-api2 = { version = "0.3.1", default-features = false }
 async-task = { version = "4.7.1", optional = true }
+foreign-types = "0.5.0"
 lock_api = "0.4.13"
 nginx-sys = { path = "nginx-sys", version = "0.5.0"}
 pin-project-lite = { version = "0.2.16", optional = true }

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::Instant;
 
-use ngx::core;
+use ngx::core::{self, ForeignTypeRef};
 use ngx::ffi::{
     ngx_array_push, ngx_command_t, ngx_conf_t, ngx_connection_t, ngx_event_t, ngx_http_handler_pt,
     ngx_http_module_t, ngx_http_phases_NGX_HTTP_ACCESS_PHASE, ngx_int_t, ngx_module_t,
@@ -171,7 +171,7 @@ http_request_handler!(async_access_handler, |request: &mut http::Request| {
     unsafe { ngx_post_event(&mut ctx.event, addr_of_mut!(ngx_posted_next_events)) };
 
     // Request is no longer needed and can be converted to something movable to the async block
-    let req = AtomicPtr::new(request.into());
+    let req = AtomicPtr::new(request.as_ptr());
     let done_flag = ctx.done.clone();
 
     let rt = ngx_http_async_runtime();

--- a/examples/upstream.rs
+++ b/examples/upstream.rs
@@ -9,7 +9,7 @@
 use std::ffi::{c_char, c_void};
 use std::mem;
 
-use ngx::core::{Pool, Status};
+use ngx::core::{ForeignTypeRef, Pool, Status};
 use ngx::ffi::{
     ngx_atoi, ngx_command_t, ngx_conf_t, ngx_connection_t, ngx_event_free_peer_pt,
     ngx_event_get_peer_pt, ngx_http_module_t, ngx_http_upstream_init_peer_pt,
@@ -133,7 +133,7 @@ http_upstream_init_peer_pt!(
         };
 
         let original_init_peer = hccf.original_init_peer.unwrap();
-        if unsafe { original_init_peer(request.into(), us) != Status::NGX_OK.into() } {
+        if unsafe { original_init_peer(request.as_ptr(), us) != Status::NGX_OK.into() } {
             return Status::NGX_ERROR;
         }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -10,6 +10,8 @@ pub use slab::SlabPool;
 pub use status::*;
 pub use string::*;
 
+pub use foreign_types::ForeignTypeRef;
+
 /// Gets an outer object pointer from a pointer to one of its fields.
 /// While there is no corresponding C macro, the pattern is common in the NGINX source.
 ///


### PR DESCRIPTION
### Proposed changes
`foreign_type::ForeignTypeRef` trait is used to define `Request` object. While generally the use of this object almost unchanged, reference trait allows to avoid unnecessary copying of original `ngx_http_request_t` data.

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have checked that all unit tests pass after adding my changes
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
