### PR TITLE
Draft: object to manipulate request context

### DIFF
--- a/examples/async.rs
+++ b/examples/async.rs
@@ -15,7 +15,10 @@ use ngx::ffi::{
     ngx_command_t, ngx_conf_t, ngx_connection_t, ngx_event_t, ngx_http_module_t, ngx_int_t,
     ngx_module_t, ngx_post_event, ngx_posted_events, ngx_posted_next_events, ngx_str_t, ngx_uint_t,
 };
-use ngx::http::{self, HttpModule, HttpModuleLocationConf, HttpRequestHandler, MergeConfigError};
+use ngx::http::{
+    self, HttpModule, HttpModuleLocationConf, HttpRequestHandler, MergeConfigError,
+    RequestWithContext,
+};
 use ngx::{ngx_conf_log_error, ngx_log_debug_http, ngx_string};
 use tokio::runtime::Runtime;
 
@@ -140,7 +143,7 @@ impl HttpRequestHandler for AsyncAccessHandler {
     const PHASE: ngx::http::HttpPhase = ngx::http::HttpPhase::Access;
     type Output = Status;
 
-    fn handler(request: &mut http::Request) -> Self::Output {
+    fn handler(mut request: &mut http::Request) -> Self::Output {
         let co = Module::location_conf(request).expect("module config is none");
 
         ngx_log_debug_http!(request, "async module enabled: {}", co.enable);
@@ -149,7 +152,10 @@ impl HttpRequestHandler for AsyncAccessHandler {
             return Status::NGX_DECLINED;
         }
 
-        if let Some(ctx) = request.get_module_ctx::<RequestCTX>(Module::module()) {
+        let rctx: &mut RequestWithContext<Module, RequestCTX>;
+        (rctx, request) = RequestWithContext::from_request(request);
+
+        if let Some(ctx) = rctx.get() {
             if !ctx.done.load(Ordering::Relaxed) {
                 return Status::NGX_AGAIN;
             }
@@ -157,13 +163,12 @@ impl HttpRequestHandler for AsyncAccessHandler {
             return Status::NGX_OK;
         }
 
-        let ctx = request.pool().allocate(RequestCTX::default());
-        if ctx.is_null() {
+        let ctx = rctx.set(RequestCTX::default());
+        if ctx.is_err() {
             return Status::NGX_ERROR;
         }
-        request.set_module_ctx(ctx.cast(), Module::module());
+        let ctx = ctx.unwrap();
 
-        let ctx = unsafe { &mut *ctx };
         ctx.event.handler = Some(check_async_work_done);
         ctx.event.data = request.connection().cast();
         ctx.event.log = unsafe { (*request.connection()).log };

--- a/examples/httporigdst.rs
+++ b/examples/httporigdst.rs
@@ -8,7 +8,7 @@ use ngx::ffi::{
     ngx_http_add_variable, ngx_http_module_t, ngx_http_variable_t, ngx_inet_get_port, ngx_int_t,
     ngx_module_t, ngx_sock_ntop, ngx_str_t, ngx_variable_value_t, sockaddr, sockaddr_storage,
 };
-use ngx::http::{self, HttpModule};
+use ngx::http::{self, HttpModule, RequestWithContext};
 use ngx::{http_variable_get, ngx_log_debug_http, ngx_string};
 
 const IPV4_STRLEN: usize = INET_ADDRSTRLEN as usize;
@@ -196,93 +196,65 @@ unsafe fn ngx_get_origdst(request: &mut http::Request) -> Result<(String, in_por
 
 http_variable_get!(
     ngx_http_orig_dst_addr_variable,
-    |request: &mut http::Request, v: *mut ngx_variable_value_t, _: usize| {
-        let ctx = request.get_module_ctx::<NgxHttpOrigDstCtx>(Module::module());
-        if let Some(obj) = ctx {
-            ngx_log_debug_http!(request, "httporigdst: found context and binding variable",);
-            unsafe { obj.bind_addr(v) };
-            return Status::NGX_OK;
-        }
-        // lazy initialization:
-        //   get original dest information
-        //   create context
-        //   set context
-        // bind address
-        ngx_log_debug_http!(request, "httporigdst: context not found, getting address");
-        let r = unsafe { ngx_get_origdst(request) };
-        match r {
-            Err(e) => {
-                return e;
+    |mut request: &mut http::Request, v: *mut ngx_variable_value_t, _: usize| {
+        let rctx: &mut RequestWithContext<Module, NgxHttpOrigDstCtx>;
+        (rctx, request) = RequestWithContext::from_request(request);
+        match rctx.get() {
+            Some(ctx) => {
+                ngx_log_debug_http!(request, "httporigdst: found context and binding variable");
+                unsafe { ctx.bind_addr(v) };
+                Status::NGX_OK
             }
-            Ok((ip, port)) => {
-                // create context,
-                // set context
-                let new_ctx = request
-                    .pool()
-                    .allocate::<NgxHttpOrigDstCtx>(Default::default());
-
-                if new_ctx.is_null() {
-                    return Status::NGX_ERROR;
-                }
-
-                ngx_log_debug_http!(
-                    request,
-                    "httporigdst: saving ip - {:?}, port - {}",
-                    ip,
-                    port,
-                );
-                unsafe { (*new_ctx).save(&ip, port, &request.pool()) };
-                unsafe { (*new_ctx).bind_addr(v) };
-                request.set_module_ctx(new_ctx as *mut c_void, Module::module());
+            None => {
+                ngx_log_debug_http!(request, "httporigdst: context not found, getting address");
+                unsafe { ngx_get_origdst(request) }.map_or_else(
+                    |e| e,
+                    |(ip, port)| {
+                        rctx.set(NgxHttpOrigDstCtx::default())
+                            .map_or(Status::NGX_ERROR, |ctx| {
+                                unsafe { ctx.bind_addr(v) };
+                                ngx_log_debug_http!(
+                                    request,
+                                    "httporigdst: saving ip - {ip}, port - {port}",
+                                );
+                                ctx.save(&ip, port, &request.pool())
+                            })
+                    },
+                )
             }
         }
-        Status::NGX_OK
     }
 );
 
 http_variable_get!(
     ngx_http_orig_dst_port_variable,
-    |request: &mut http::Request, v: *mut ngx_variable_value_t, _: usize| {
-        let ctx = request.get_module_ctx::<NgxHttpOrigDstCtx>(Module::module());
-        if let Some(obj) = ctx {
-            ngx_log_debug_http!(request, "httporigdst: found context and binding variable",);
-            unsafe { obj.bind_port(v) };
-            return Status::NGX_OK;
-        }
-        // lazy initialization:
-        //   get original dest information
-        //   create context
-        //   set context
-        // bind port
-        ngx_log_debug_http!(request, "httporigdst: context not found, getting address");
-        let r = unsafe { ngx_get_origdst(request) };
-        match r {
-            Err(e) => {
-                return e;
+    |mut request: &mut http::Request, v: *mut ngx_variable_value_t, _: usize| {
+        let rctx: &mut RequestWithContext<Module, NgxHttpOrigDstCtx>;
+        (rctx, request) = RequestWithContext::from_request(request);
+        match rctx.get() {
+            Some(ctx) => {
+                ngx_log_debug_http!(request, "httporigdst: found context and binding variable");
+                unsafe { ctx.bind_port(v) };
+                Status::NGX_OK
             }
-            Ok((ip, port)) => {
-                // create context,
-                // set context
-                let new_ctx = request
-                    .pool()
-                    .allocate::<NgxHttpOrigDstCtx>(Default::default());
-
-                if new_ctx.is_null() {
-                    return Status::NGX_ERROR;
-                }
-
-                ngx_log_debug_http!(
-                    request,
-                    "httporigdst: saving ip - {:?}, port - {}",
-                    ip,
-                    port,
-                );
-                unsafe { (*new_ctx).save(&ip, port, &request.pool()) };
-                unsafe { (*new_ctx).bind_port(v) };
-                request.set_module_ctx(new_ctx as *mut c_void, Module::module());
+            None => {
+                ngx_log_debug_http!(request, "httporigdst: context not found, getting address");
+                unsafe { ngx_get_origdst(request) }.map_or_else(
+                    |e| e,
+                    |(ip, port)| {
+                        rctx.set(NgxHttpOrigDstCtx::default())
+                            .map_or(Status::NGX_ERROR, |ctx| {
+                                unsafe { ctx.bind_port(v) };
+                                ngx_log_debug_http!(
+                                    request,
+                                    "httporigdst: saving ip - {ip}, port - {port}",
+                                );
+                                ctx.save(&ip, port, &request.pool())
+                            })
+                    },
+                )
             }
         }
-        Status::NGX_OK
     }
 );
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1,10 +1,12 @@
 mod conf;
 mod module;
 mod request;
+mod request_context;
 mod status;
 mod upstream;
 
 pub use conf::*;
 pub use module::*;
 pub use request::*;
+pub use request_context::*;
 pub use status::*;

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -1,5 +1,4 @@
 use core::error;
-use core::ffi::c_void;
 use core::fmt;
 use core::ptr::NonNull;
 use core::slice;
@@ -236,28 +235,6 @@ impl Request {
         unsafe { (*self.connection()).log }
     }
 
-    /// Get Module context pointer
-    fn get_module_ctx_ptr(&self, module: &ngx_module_t) -> *mut c_void {
-        unsafe { *self.0.ctx.add(module.ctx_index) }
-    }
-
-    /// Get Module context
-    pub fn get_module_ctx<T>(&self, module: &ngx_module_t) -> Option<&T> {
-        let ctx = self.get_module_ctx_ptr(module).cast::<T>();
-        // SAFETY: ctx is either NULL or allocated with ngx_p(c)alloc and
-        // explicitly initialized by the module
-        unsafe { ctx.as_ref() }
-    }
-
-    /// Sets the value as the module's context.
-    ///
-    /// See <https://nginx.org/en/docs/dev/development_guide.html#http_request>
-    pub fn set_module_ctx(&self, value: *mut c_void, module: &ngx_module_t) {
-        unsafe {
-            *self.0.ctx.add(module.ctx_index) = value;
-        };
-    }
-
     /// Get the value of a [complex value].
     ///
     /// [complex value]: https://nginx.org/en/docs/dev/development_guide.html#http_complex_values
@@ -384,65 +361,6 @@ impl Request {
         Status::NGX_DONE
     }
 
-    /// Send a subrequest
-    pub fn subrequest(
-        &self,
-        uri: &str,
-        module: &ngx_module_t,
-        post_callback: unsafe extern "C" fn(
-            *mut ngx_http_request_t,
-            *mut c_void,
-            ngx_int_t,
-        ) -> ngx_int_t,
-    ) -> Status {
-        let uri_ptr = unsafe { &mut ngx_str_t::from_str(self.0.pool, uri) as *mut _ };
-        // -------------
-        // allocate memory and set values for ngx_http_post_subrequest_t
-        let sub_ptr = self
-            .pool()
-            .alloc(core::mem::size_of::<ngx_http_post_subrequest_t>());
-
-        // assert!(sub_ptr.is_null());
-        let post_subreq =
-            sub_ptr as *const ngx_http_post_subrequest_t as *mut ngx_http_post_subrequest_t;
-        unsafe {
-            (*post_subreq).handler = Some(post_callback);
-            // WARN: safety! ensure that ctx is already set
-            (*post_subreq).data = self.get_module_ctx_ptr(module);
-        }
-        // -------------
-
-        let mut psr: *mut ngx_http_request_t = core::ptr::null_mut();
-        let r = unsafe {
-            ngx_http_subrequest(
-                (self as *const Request as *mut Request).cast(),
-                uri_ptr,
-                core::ptr::null_mut(),
-                &raw mut psr,
-                sub_ptr as *mut _,
-                NGX_HTTP_SUBREQUEST_WAITED as _,
-            )
-        };
-
-        // previously call of ngx_http_subrequest() would ensure that the pointer is not null
-        // anymore
-        let sr = unsafe { &mut *psr };
-
-        /*
-         * allocate fake request body to avoid attempts to read it and to make
-         * sure real body file (if already read) won't be closed by upstream
-         */
-        sr.request_body =
-            self.pool()
-                .alloc(core::mem::size_of::<ngx_http_request_body_t>()) as *mut _;
-
-        if sr.request_body.is_null() {
-            return Status::NGX_ERROR;
-        }
-        sr.set_header_only(1 as _);
-        Status(r)
-    }
-
     /// Iterate over headers_in
     /// each header item is (&str, &str) (borrowed)
     pub fn headers_in_iterator(&self) -> NgxListIterator<'_> {
@@ -484,10 +402,6 @@ impl crate::http::HttpModuleConfExt for Request {
         }
     }
 }
-
-// trait OnSubRequestDone {
-
-// }
 
 impl fmt::Debug for Request {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/http/request_context.rs
+++ b/src/http/request_context.rs
@@ -1,0 +1,88 @@
+use core::ffi::c_void;
+use core::marker::PhantomData;
+
+use allocator_api2::alloc::AllocError;
+use nginx_sys::ngx_http_request_t;
+
+use crate::{
+    core::Pool,
+    http::{HttpModule, Request},
+};
+
+/// Request wrapper with context support.
+pub struct RequestWithContext<M, T>(ngx_http_request_t, PhantomData<(M, T)>)
+where
+    M: HttpModule,
+    T: Sized;
+
+impl<M, T> RequestWithContext<M, T>
+where
+    M: HttpModule,
+    T: Sized,
+{
+    /// Creates a new `RequestWithContext` from a raw pointer to `ngx_http_request_t`.
+    ///
+    /// # Safety
+    ///
+    /// The caller has provided a valid non-null pointer to a valid `ngx_http_request_t`
+    /// which shares the same representation as `Request`.
+    pub unsafe fn from_ngx_http_request<'a>(r: *mut ngx_http_request_t) -> &'a mut Self {
+        unsafe { &mut *r.cast::<Self>() }
+    }
+
+    /// Creates a new `RequestWithContext` from a `Request`.
+    pub fn from_request(r: &mut Request) -> (&mut Self, &mut Request) {
+        let rptr: *mut ngx_http_request_t = r.into();
+        unsafe { (&mut *rptr.cast::<Self>(), r) }
+    }
+
+    /// Get Module context pointer
+    #[inline]
+    fn get_module_ctx_ptr(&self) -> *mut c_void {
+        unsafe { *self.0.ctx.add(M::module().ctx_index) }
+    }
+
+    /// Check if module context exists for a specific module.
+    pub fn exists(&self) -> bool {
+        !self.get_module_ctx_ptr().is_null()
+    }
+
+    /// Get module context for a specific module,
+    /// returning `None` if the context is not set.
+    pub fn get(&self) -> Option<&T> {
+        let ctx_ptr = self.get_module_ctx_ptr();
+        if ctx_ptr.is_null() {
+            None
+        } else {
+            Some(unsafe { &*ctx_ptr.cast::<T>() })
+        }
+    }
+
+    /// Set module context for a specific module, returning a mutable reference to the context
+    /// or an `AllocError` if allocation fails.
+    pub fn set(&mut self, value: T) -> Result<&mut T, AllocError> {
+        let pool = unsafe { Pool::from_ngx_pool(self.0.pool) };
+        let ctx_ptr = pool.allocate::<T>(value) as *mut c_void;
+        if ctx_ptr.is_null() {
+            return Err(AllocError);
+        }
+        unsafe {
+            *self.0.ctx.add(M::module().ctx_index) = ctx_ptr;
+        }
+        Ok(unsafe { &mut *ctx_ptr.cast::<T>() })
+    }
+
+    /// Modify the module context for a specific module using a provided closure,
+    /// returning a reference to the modified context
+    pub fn modify(&mut self, f: impl FnOnce(&mut T, &Request)) -> Option<&T> {
+        let ctx_ptr = self.get_module_ctx_ptr();
+        if ctx_ptr.is_null() {
+            None
+        } else {
+            let ctx_ref = unsafe { &mut *ctx_ptr.cast::<T>() };
+            let req = unsafe { Request::from_ngx_http_request(&raw mut self.0) };
+            f(ctx_ref, req);
+            Some(ctx_ref as &T)
+        }
+    }
+}


### PR DESCRIPTION
Simple object to manipulate HTTP module context in request handlers.

- The object is implemented as a separate `RequestWithContext` wrapper around a pointer to `ngx_http_request_t`.
- Context-related methods are removed from `Request` wrapper.
- The new wrapper can be created consuming and re-creating `&mut Request` instance. This allow to have simultaneous mutable references to module context instance and to original `Request`.
- `RequestWithContext` wrapper implements minimal required set of methods to work with context: `get`, `set`, `modify`, `exists`.
