### PR TITLE
fix:  ensure ngx_log_error and ngx_conf_log_error correctly filter log levels

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -97,7 +97,7 @@ macro_rules! ngx_log_error {
     ( $level:expr, $log:expr, $($arg:tt)+ ) => {
         let log = $log;
         let level = $level as $crate::ffi::ngx_uint_t;
-        if level < unsafe { (*log).log_level } {
+        if level <= unsafe { (*log).log_level } {
             let mut buf =
                 [const { ::core::mem::MaybeUninit::<u8>::uninit() }; $crate::log::LOG_BUFFER_SIZE];
             let message = $crate::log::write_fmt(&mut buf, format_args!($($arg)+));
@@ -112,7 +112,7 @@ macro_rules! ngx_conf_log_error {
     ( $level:expr, $cf:expr, $($arg:tt)+ ) => {
         let cf: *mut $crate::ffi::ngx_conf_t = $cf;
         let level = $level as $crate::ffi::ngx_uint_t;
-        if level < unsafe { (*(*cf).log).log_level } {
+        if level <= unsafe { (*(*cf).log).log_level } {
             let mut buf =
                 [const { ::core::mem::MaybeUninit::<u8>::uninit() }; $crate::log::LOG_BUFFER_SIZE];
             let message = $crate::log::write_fmt(&mut buf, format_args!($($arg)+));


### PR DESCRIPTION
### Proposed changes

currently, the filtering logic incorrectly excludes messages that match exactly the configured log level threshold.
the fix corrects the logic.

Closes: https://github.com/nginx/ngx-rust/issues/266

### Checklist
Before creating a PR, run through this checklist and mark each as complete.

- [x] I have written my commit messages in the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] I have added tests (when possible) that prove my fix is effective or that my feature works
- [ ] I have checked that all unit tests pass after adding my changes
- [ ] I have updated necessary documentation
- [x] I have rebased my branch onto main
- [x] I will ensure my PR is targeting the main branch and pulling from my branch from my own fork
