### PR TITLE
fix(examples): generate more portable Makefiles

### DIFF
--- a/examples/auto/rust
+++ b/examples/auto/rust
@@ -308,12 +308,24 @@ ngx_rust_make_module () {
         ngx_rustc_module_opt="--example $ngx_rust_target_name"
     fi
 
+    if [ -z "$ngx_rust_phony_emitted" ]; then
+        ngx_rust_phony_emitted=1
+
+        # Make cannot track the Rust module source and dependency changes,
+        # so we defer the task to cargo and invoke it unconditionally.
+        #
+        # We have to use the pseudotarget instead of .PHONY for better
+        # compatibility with various Make implementations.
+        cat <<END                                             >> $NGX_MAKEFILE
+
+.NGX_RUST_PHONY: ;
+
+END
+    fi
+
     cat << END                                                >> $NGX_MAKEFILE
 
-# always run cargo instead of trying to track the source modifications
-.PHONY: $ngx_rust_obj
-
-$ngx_rust_obj:
+$ngx_rust_obj: .NGX_RUST_PHONY
 	$NGX_CARGO rustc \\
 		--config $ngx_cargo_config \\
 		--crate-type staticlib \\


### PR DESCRIPTION
The change should resolve our intermittent CI issues caused by absence of .PHONY in NMAKE.

Tested: NMAKE 14.44, GNU Make 4.4.1, GNU Make 3.81, bmake 20230711, pdpmake 2.0.4, ~~SUN~~Oracle&trade; make.