### PR TITLE
fix: double-free in ngx::async_::Resolver

### DIFF
--- a/src/async_/resolver.rs
+++ b/src/async_/resolver.rs
@@ -186,6 +186,8 @@ impl<'a> Resolution<'a> {
         // timeout.
         let ret = unsafe { ngx_resolve_name(ctxp.as_ptr()) };
         if let Some(e) = NonZero::new(ret) {
+            // ngx_resolve_name will free the context on error.
+            core::mem::forget(this.ctx.take());
             return Err(Error::Resolver(ResolverError::from(e), name.to_string()));
         }
 

--- a/src/async_/resolver.rs
+++ b/src/async_/resolver.rs
@@ -23,7 +23,7 @@ use nginx_sys::{
 use crate::{
     allocator::Box,
     collections::Vec,
-    core::Pool,
+    core::{Pool, Status},
     ffi::{
         ngx_addr_t, ngx_msec_t, ngx_resolve_name, ngx_resolve_start, ngx_resolver_ctx_t,
         ngx_resolver_t, ngx_str_t,
@@ -39,6 +39,8 @@ pub enum Error {
     Resolver(ResolverError, String),
     /// Allocation failed
     AllocationFailed,
+    /// Unknown internal error while starting name resolution
+    Internal,
 }
 
 impl fmt::Display for Error {
@@ -47,6 +49,7 @@ impl fmt::Display for Error {
             Error::NoResolver => write!(f, "No resolver configured"),
             Error::Resolver(err, context) => write!(f, "{err}: resolving `{context}`"),
             Error::AllocationFailed => write!(f, "Allocation failed"),
+            Error::Internal => write!(f, "Internal error"),
         }
     }
 }
@@ -184,11 +187,11 @@ impl<'a> Resolution<'a> {
         // cache, the handler may get called from this stack. Otherwise, it
         // will be called later by nginx when it gets a dns response or a
         // timeout.
-        let ret = unsafe { ngx_resolve_name(ctxp.as_ptr()) };
-        if let Some(e) = NonZero::new(ret) {
+        let ret = unsafe { Status(ngx_resolve_name(ctxp.as_ptr())) };
+        if !ret.is_ok() {
             // ngx_resolve_name will free the context on error.
             core::mem::forget(this.ctx.take());
-            return Err(Error::Resolver(ResolverError::from(e), name.to_string()));
+            return Err(Error::Internal);
         }
 
         Ok(this)


### PR DESCRIPTION
The most likely cause for this scenario is allocation error. It's not possible to trigger it externally, because `ngx_resolve_name` returns an error before contacting the nameserver.

See also `ngx_http_upstream_init_request` or `ngx_stream_proxy_handler` for similar pattern of storing `ngx_resolver_ctx_t`.