### PR TITLE
async: always defer task wakes via ngx_post_event

### DIFF
--- a/src/async_/spawn.rs
+++ b/src/async_/spawn.rs
@@ -118,13 +118,16 @@ impl Drop for SchedulerInner {
     }
 }
 
-fn schedule(runnable: Runnable, info: ScheduleInfo) {
-    if info.woken_while_running {
-        SCHEDULER.schedule(runnable);
-        ngx_log_debug!(ngx_cycle_log().as_ptr(), "async: task scheduled while running");
-    } else {
-        runnable.run();
-    }
+fn schedule(runnable: Runnable, _info: ScheduleInfo) {
+    // Always defer the wake via `ngx_post_event`; never re-poll synchronously.
+    //
+    // `Waker::wake()` may fire from arbitrary contexts, including a future's
+    // `Drop` while a lock is held (e.g. h2's `Streams::drop` wakes its parked
+    // `Connection` task while holding `Arc<Mutex<Inner>>`). A synchronous
+    // re-poll would re-enter the task and deadlock on that lock. Deferring
+    // costs one event-loop tick: `ngx_event_process_posted` drains the queue
+    // at the end of each cycle.
+    SCHEDULER.schedule(runnable);
 }
 
 /// Creates a new task running on the NGINX event loop.


### PR DESCRIPTION
Fixes #294.

`schedule()` ran `runnable.run()` synchronously when a task was woken from
outside its own poll. But `Waker::wake()` may be called from any context,
including a `Drop` that is holding a lock the woken task also needs — e.g. h2's
`Streams::drop` — and re-polling inline then re-enters that task on the caller's
stack and deadlocks on the held lock. Since the executor can't tell whether a
wake's caller is holding such a lock, it shouldn't re-poll inside `wake()` at
all. This always defers the wake via `ngx_post_event` (one event-loop tick).

- **fix:** drop the synchronous `runnable.run()`; always `SCHEDULER.schedule()`.
- **test:** freestanding reproducer (only `async_task`) — synchronous re-poll
  reproduces the held-lock deadlock signature, deferred re-poll avoids it; no
  NGINX event loop needed.

Verified on Linux + macOS aarch64: `cargo test` / `clippy --all-targets -Dwarnings`
/ `fmt --check` all clean.
