### PR TITLE
fix: invalid context for unconfigured resolver in ngx::async_::Resolver

### DIFF
--- a/nginx-sys/src/lib.rs
+++ b/nginx-sys/src/lib.rs
@@ -45,6 +45,13 @@ pub use stream::*;
 /// Default alignment for pool allocations.
 pub const NGX_ALIGNMENT: usize = NGX_RS_ALIGNMENT;
 
+/// Sentinel returned by `ngx_resolve_start()` when no resolver is configured.
+///
+/// nginx's `NGX_NO_RESOLVER` macro expands to `(void *) -1`, which bindgen does
+/// not emit. It is an address-only sentinel that must never be dereferenced;
+/// callers compare the `ngx_resolve_start()` return value against it.
+pub const NGX_NO_RESOLVER: *mut ngx_resolver_ctx_t = ptr::without_provenance_mut(usize::MAX);
+
 // Check if the allocations made with ngx_palloc are properly aligned.
 // If the check fails, objects allocated from `ngx_pool` can violate Rust pointer alignment
 // requirements.

--- a/src/async_/resolver.rs
+++ b/src/async_/resolver.rs
@@ -16,8 +16,8 @@ use core::ptr::NonNull;
 use core::task::{Context, Poll, Waker};
 
 use nginx_sys::{
-    NGX_RESOLVE_FORMERR, NGX_RESOLVE_NOTIMP, NGX_RESOLVE_NXDOMAIN, NGX_RESOLVE_REFUSED,
-    NGX_RESOLVE_SERVFAIL, NGX_RESOLVE_TIMEDOUT,
+    NGX_NO_RESOLVER, NGX_RESOLVE_FORMERR, NGX_RESOLVE_NOTIMP, NGX_RESOLVE_NXDOMAIN,
+    NGX_RESOLVE_REFUSED, NGX_RESOLVE_SERVFAIL, NGX_RESOLVE_TIMEDOUT,
 };
 
 use crate::{
@@ -276,6 +276,9 @@ impl ResolverCtx {
     /// `temp` contains a name which is textual form of an addr.
     pub fn new(resolver: NonNull<ngx_resolver_t>) -> Result<Self, Error> {
         let ctx = unsafe { ngx_resolve_start(resolver.as_ptr(), core::ptr::null_mut()) };
+        if ctx == NGX_NO_RESOLVER {
+            return Err(Error::NoResolver);
+        }
         NonNull::new(ctx).map(Self).ok_or(Error::AllocationFailed)
     }
 


### PR DESCRIPTION
ngx_resolve_start() returns the NGX_NO_RESOLVER sentinel ((void *) -1) when the resolver has no nameservers configured. This pointer is non-null, so NonNull::new() accepted it as a valid context and it was later dereferenced and dropped via ngx_resolve_name_done(), causing invalid memory access.
